### PR TITLE
kernel-module-mmngrbuf: make a pseudo to ignore the ${KERNELSRC}/include

### DIFF
--- a/meta-xt-domx/recipes-kernel/kernel-module-mmngr/kernel-module-mmngrbuf.bbappend
+++ b/meta-xt-domx/recipes-kernel/kernel-module-mmngr/kernel-module-mmngrbuf.bbappend
@@ -1,0 +1,1 @@
+PSEUDO_IGNORE_PATHS .= ",${KERNELSRC}/include"


### PR DESCRIPTION
It is necessary because some of the do_install methods from different components
modify the directory ${KERNELSRC}/include, it bring the pseudo error and stop the build.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>