### PR TITLE
URIs: replace git protocol with https one for the github sources.

### DIFF
--- a/meta-xt-dom0/recipes-kernel/linux/linux-generic-armv8.bbappend
+++ b/meta-xt-dom0/recipes-kernel/linux/linux-generic-armv8.bbappend
@@ -5,6 +5,6 @@ SRCREV = "${AUTOREV}"
 LINUX_VERSION = "5.10.0"
 
 SRC_URI = " \
-    git://github.com/xen-troops/linux.git;branch=${BRANCH} \
+    git://github.com/xen-troops/linux.git;branch=${BRANCH};protocol=https \
     file://defconfig \
   "

--- a/meta-xt-domx/recipes-core/dbus/dbus-cxx_0.10.0.bb
+++ b/meta-xt-domx/recipes-core/dbus/dbus-cxx_0.10.0.bb
@@ -6,7 +6,7 @@ DEPENDS = "boost dbus libsigc++-2.0"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
-SRC_URI = "git://github.com/dbus-cxx/${PN}.git;nobranch=1;tag=${PV}"
+SRC_URI = "git://github.com/dbus-cxx/${PN}.git;nobranch=1;tag=${PV};protocol=https"
 S = "${WORKDIR}/git"
 
 inherit autotools-brokensep pkgconfig

--- a/meta-xt-driver-domain/recipes-extended/xt-log/xt-log_git.bb
+++ b/meta-xt-driver-domain/recipes-extended/xt-log/xt-log_git.bb
@@ -3,7 +3,7 @@ SECTION = "libs"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-SRC_URI = "git://github.com/xen-troops/${BPN}.git;branch=yocto-v4.7.0-xt0.1"
+SRC_URI = "git://github.com/xen-troops/${BPN}.git;protocol=https;branch=yocto-v4.7.0-xt0.1"
 SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Use https instead of git because unauthenticated git protocol is disabled by github

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>