### PR TITLE
xen: add variable XEN_URL to customize the xen source.

### DIFF
--- a/meta-xt-domx/recipes-extended/xen/xen-source.inc
+++ b/meta-xt-domx/recipes-extended/xen/xen-source.inc
@@ -1,6 +1,8 @@
 LIC_FILES_CHKSUM = "file://COPYING;md5=419739e325a50f3d7b4501338e44a4e5"
 
-SRC_URI = "git://github.com/xen-troops/xen.git;protocol=https;branch=xen-4.16rc-migration"
+XEN_URL ??= "git://github.com/xen-troops/xen.git;protocol=https;branch=xen-4.16rc-migration"
+
+SRC_URI = "${XEN_URL}"
 XEN_REL = "4.16"
 PV = "${XEN_REL}.0+git${SRCPV}"
 SRCREV = "${AUTOREV}"


### PR DESCRIPTION
It has been done to avoid overriding of the SRC_URI in multiple recipes and allow to
set the URL in [prod].yaml file. Now it is not necessary to implement the recipe(s)
just to update the source of xen.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>