### PR TITLE
sndbe: update recipe to support both pulseaudio and alsa

### DIFF
--- a/meta-xt-driver-domain/recipes-extended/sndbe/files/sndbe.service
+++ b/meta-xt-driver-domain/recipes-extended/sndbe/files/sndbe.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Sound backend
-Requires=proc-xen.mount pulseaudio.service
-After=proc-xen.mount pulseaudio.service
+Requires=proc-xen.mount sound.target
+After=proc-xen.mount sound.target
 
 [Service]
 Type=simple

--- a/meta-xt-driver-domain/recipes-extended/sndbe/sndbe_git.bb
+++ b/meta-xt-driver-domain/recipes-extended/sndbe/sndbe_git.bb
@@ -5,8 +5,13 @@ PR = "r0"
 
 inherit pkgconfig cmake systemd
 
-DEPENDS = "libxenbe libconfig pulseaudio git-native"
-RDEPENDS_${PN} = "libxenbe libconfig pulseaudio-server"
+PACKAGECONFIG ??= "${@bb.utils.filter('DISTRO_FEATURES', 'pulseaudio alsa', d)}"
+PACKAGECONFIG[pulseaudio] = "-DWITH_PULSE=ON,-DWITH_PULSE=OFF,pulseaudio,pulseaudio-server"
+PACKAGECONFIG[alsa] = "-DWITH_ALSA=ON,-DWITH_ALSA=OFF,alsa-lib,alsa-server"
+
+DEPENDS = "libxenbe libconfig git-native"
+
+RDEPENDS_${PN} = "libxenbe libconfig"
 
 SRC_URI = " \
     git://github.com/xen-troops/snd_be.git;protocol=https;branch=yocto-v4.7.0-xt0.1 \
@@ -18,7 +23,7 @@ S = "${WORKDIR}/git"
 
 SRCREV = "${AUTOREV}"
 
-EXTRA_OECMAKE = " -DWITH_DOC=OFF -DWITH_PULSE=ON"
+EXTRA_OECMAKE = " -DWITH_DOC=OFF"
 
 SYSTEMD_SERVICE_${PN} = "sndbe.service"
 

--- a/meta-xt-driver-domain/recipes-multimedia/pulseaudio/files/pulseaudio.service
+++ b/meta-xt-driver-domain/recipes-multimedia/pulseaudio/files/pulseaudio.service
@@ -6,4 +6,4 @@ Type=notify
 ExecStart=/usr/bin/pulseaudio --daemonize=no --system --realtime --disallow-exit --log-target=journal
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=sound.target

--- a/meta-xt-driver-domain/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
+++ b/meta-xt-driver-domain/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
@@ -34,7 +34,10 @@ do_install_append () {
     rm ${D}/${sysconfdir}/pulse/default.pa
 
     install -d ${D}${systemd_system_unitdir}
+    install -d ${D}${systemd_system_unitdir}/sound.target.wants
     install -m 0644 ${WORKDIR}/pulseaudio.service ${D}${systemd_system_unitdir}
+    ln -sf ${systemd_system_unitdir}/pulseaudio.service \
+        ${D}${systemd_system_unitdir}/sound.target.wants/pulseaudio.service
 
     set_cfg_value ${D}/${sysconfdir}/pulse/client.conf autospawn no
     set_cfg_value ${D}/${sysconfdir}/pulse/client.conf default-server /var/run/pulse/native


### PR DESCRIPTION
Configure sndbe based on DISTRO_FEATURE entry to support alsa or
pulseaudio.

Signed-off-by: Oleksii Moisieiev <oleksii_moisieiev@epam.com>