### PR TITLE
displaymanager: switch displbe and displaymanager to weston env file

### DIFF
--- a/meta-xt-driver-domain/recipes-extended/displaymanager/files/display-manager.service
+++ b/meta-xt-driver-domain/recipes-extended/displaymanager/files/display-manager.service
@@ -4,7 +4,7 @@ Requires=dbus.service
 After=dbus.service weston@root.service
 
 [Service]
-Environment="XDG_RUNTIME_DIR=/run/user/0"
+EnvironmentFile=/etc/default/weston
 Type=dbus
 BusName=com.epam.DisplayManager
 ExecStartPre=/usr/bin/weston-info

--- a/meta-xt-driver-domain/recipes-extended/displbe/files/displbe.service
+++ b/meta-xt-driver-domain/recipes-extended/displbe/files/displbe.service
@@ -4,7 +4,7 @@ After=weston@%u.service
 
 [Service]
 Type=simple
-Environment="XDG_RUNTIME_DIR=/run/user/%U"
+EnvironmentFile=/etc/default/weston
 TimeoutStartSec=1
 ExecStart=/usr/bin/displ_be
 ExecStartPost=/usr/bin/xenstore-write drivers/displbe/status ready


### PR DESCRIPTION
Weston service is using /etc/default/weston file to populate weston
environment to the service. Displaymanager and displ_be should use the
same file because they are dependend from weston.

Signed-off-by: Oleksii Moisieiev <oleksii_moisieiev@epam.com>