### PR TITLE
dom0: add xentop to the resulting image

### DIFF
--- a/meta-xt-dom0/recipes-core/images/core-image-thin-initramfs.bb
+++ b/meta-xt-dom0/recipes-core/images/core-image-thin-initramfs.bb
@@ -4,7 +4,7 @@ configured. RAM-based Initial Root Filesystem (initramfs) is used to avoid \
 need for accessing block/mtd devices. Shall contain kernel images for other \
 VMs."
 
-IMAGE_INSTALL = "packagegroup-core-boot ${CORE_IMAGE_EXTRA_INSTALL}"
+IMAGE_INSTALL = "packagegroup-core-boot ${CORE_IMAGE_EXTRA_INSTALL} xen-tools-xenstat"
 
 IMAGE_LINGUAS = ""
 


### PR DESCRIPTION
Add xen-tools-xenstat, which provides xentop
to the resulting dom0 image.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>