### PR TITLE
doma: provide the ability to override u-boot source url

### DIFF
--- a/meta-xt-control-domain/recipes-guest/doma/u-boot-android.bb
+++ b/meta-xt-control-domain/recipes-guest/doma/u-boot-android.bb
@@ -5,8 +5,9 @@ UBOOT_CONFIG[doma] = "xenguest_arm64_android_defconfig"
 UBOOT_CONFIG = "doma"
 
 SRCREV = "${AUTOREV}"
+UBOOT_SOURCE ??= "git://github.com/xen-troops/u-boot.git;protocol=https;branch=android-master;"
 SRC_URI = "\
-    git://github.com/xen-troops/u-boot.git;protocol=https;branch=android-master; \
+    ${UBOOT_SOURCE} \
 "
 
 FILES_${PN} = " \


### PR DESCRIPTION
Some products need specific source branches for doma
u-boot. Provide a mechanism to be able to override
u-boot source url.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>