### PR TITLE
domd: Remove product specific packages

### DIFF
--- a/meta-xt-driver-domain/recipes-graphics/images/core-image-weston.bbappend
+++ b/meta-xt-driver-domain/recipes-graphics/images/core-image-weston.bbappend
@@ -4,9 +4,7 @@ IMAGE_INSTALL_append = " \
 	      xen-tools-scripts-network \
 	      xen-tools-scripts-block \
 	      xen-tools-xenstore \
-	      sndbe \
 	      displbe \
-	      camerabe \
 	      xen-network \
 	      dnsmasq \
 	      optee-os \


### PR DESCRIPTION
`sndbe` and `camerabe` are product specific things, so should
be added in product's bbappend-files.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>