### PR TITLE
Xenstore dependencies

### DIFF
--- a/meta-xt-driver-domain/recipes-connectivity/xen-network/files/bridge-up-notification.service
+++ b/meta-xt-driver-domain/recipes-connectivity/xen-network/files/bridge-up-notification.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Bridge up notification
-Wants=systemd-networkd-wait-online.service
-After=systemd-networkd-wait-online.service
+Wants=systemd-networkd-wait-online.service xenstored.service
+After=systemd-networkd-wait-online.service xenstored.service
 
 [Service]
 Type=simple

--- a/meta-xt-driver-domain/recipes-connectivity/xen-network/xen-network.bb
+++ b/meta-xt-driver-domain/recipes-connectivity/xen-network/xen-network.bb
@@ -36,6 +36,7 @@ RDEPENDS_${PN} = " \
     kernel-module-xt-nat \
     kernel-module-xt-tcpudp \
     kernel-module-xt-masquerade \
+    xen-tools-xenstore \
 "
 
 do_install() {

--- a/meta-xt-driver-domain/recipes-connectivity/xen-network/xen-network.bb
+++ b/meta-xt-driver-domain/recipes-connectivity/xen-network/xen-network.bb
@@ -39,6 +39,10 @@ RDEPENDS_${PN} = " \
     xen-tools-xenstore \
 "
 
+RRECOMMENDS_${PN} += " \
+    virtual/xenstored \
+"
+
 do_install() {
     # Install bridge/network artifacts
     install -d ${D}${systemd_system_unitdir}

--- a/meta-xt-driver-domain/recipes-extended/block/block.bb
+++ b/meta-xt-driver-domain/recipes-extended/block/block.bb
@@ -13,6 +13,10 @@ inherit systemd
 
 SYSTEMD_SERVICE_${PN} = "block-up-notification.service"
 
+RDEPDENDS_${PN} += " \
+    xen-tools-xenstore \
+"
+
 FILES_${PN} = " \
     ${systemd_system_unitdir}/block-up-notification.service \
 "

--- a/meta-xt-driver-domain/recipes-extended/block/block.bb
+++ b/meta-xt-driver-domain/recipes-extended/block/block.bb
@@ -17,6 +17,10 @@ RDEPDENDS_${PN} += " \
     xen-tools-xenstore \
 "
 
+RRECOMMENDS_${PN} += " \
+    virtual/xenstored \
+"
+
 FILES_${PN} = " \
     ${systemd_system_unitdir}/block-up-notification.service \
 "

--- a/meta-xt-driver-domain/recipes-extended/block/files/block-up-notification.service
+++ b/meta-xt-driver-domain/recipes-extended/block/files/block-up-notification.service
@@ -2,8 +2,8 @@
 Description=Block device ready notification
 # Assuming that -.mount will mount root file system
 # and PV Block should be functional at that time
-Wants=-.mount
-After=-.mount
+Wants=-.mount xenstored.service
+After=-.mount xenstored.service
 
 [Service]
 Type=simple

--- a/meta-xt-driver-domain/recipes-extended/camerabe/camerabe_git.bb
+++ b/meta-xt-driver-domain/recipes-extended/camerabe/camerabe_git.bb
@@ -26,6 +26,10 @@ RDEPDENDS_${PN} += " \
     xen-tools-xenstore \
 "
 
+RRECOMMENDS_${PN} += " \
+    virtual/xenstored \
+"
+
 EXTRA_OECMAKE_append_rcar = " -DWITH_DOC=OFF"
 
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/meta-xt-driver-domain/recipes-extended/camerabe/camerabe_git.bb
+++ b/meta-xt-driver-domain/recipes-extended/camerabe/camerabe_git.bb
@@ -22,6 +22,10 @@ SRC_URI = " \
 
 SRCREV = "${AUTOREV}"
 
+RDEPDENDS_${PN} += " \
+    xen-tools-xenstore \
+"
+
 EXTRA_OECMAKE_append_rcar = " -DWITH_DOC=OFF"
 
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/meta-xt-driver-domain/recipes-extended/camerabe/files/camerabe.service
+++ b/meta-xt-driver-domain/recipes-extended/camerabe/files/camerabe.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Camera backend
 Requires=proc-xen.mount
-After=proc-xen.mount
+Wants=xenstored.service
+After=proc-xen.mount xenstored.service
 
 [Service]
 Type=simple

--- a/meta-xt-driver-domain/recipes-extended/displbe/displbe_git.bb
+++ b/meta-xt-driver-domain/recipes-extended/displbe/displbe_git.bb
@@ -22,6 +22,10 @@ DEPENDS = "libxenbe libconfig libdrm wayland git-native wayland-ivi-extension wa
 
 EXTRA_OECMAKE = " -DWITH_DOC=OFF -DWITH_DRM=ON -DWITH_ZCOPY=ON -DWITH_WAYLAND=ON -DWITH_IVI_EXTENSION=ON -DWITH_INPUT=ON"
 
+RDEPDENDS_${PN} += " \
+    xen-tools-xenstore \
+"
+
 FILES_${PN} += " \
     ${systemd_system_unitdir}/displbe.service \
 "

--- a/meta-xt-driver-domain/recipes-extended/displbe/displbe_git.bb
+++ b/meta-xt-driver-domain/recipes-extended/displbe/displbe_git.bb
@@ -26,6 +26,10 @@ RDEPDENDS_${PN} += " \
     xen-tools-xenstore \
 "
 
+RRECOMMENDS_${PN} += " \
+    virtual/xenstored \
+"
+
 FILES_${PN} += " \
     ${systemd_system_unitdir}/displbe.service \
 "

--- a/meta-xt-driver-domain/recipes-extended/displbe/files/displbe.service
+++ b/meta-xt-driver-domain/recipes-extended/displbe/files/displbe.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Display backend
-After=weston@%u.service
+Wants=xenstored.service
+After=xenstored.service weston@%u.service
 
 [Service]
 Type=simple

--- a/meta-xt-driver-domain/recipes-extended/sndbe/files/sndbe.service
+++ b/meta-xt-driver-domain/recipes-extended/sndbe/files/sndbe.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Sound backend
 Requires=proc-xen.mount sound.target
-After=proc-xen.mount sound.target
+Wants=xenstored.service
+After=proc-xen.mount sound.target xenstored.service
 
 [Service]
 Type=simple

--- a/meta-xt-driver-domain/recipes-extended/sndbe/sndbe_git.bb
+++ b/meta-xt-driver-domain/recipes-extended/sndbe/sndbe_git.bb
@@ -17,6 +17,10 @@ RDEPDENDS_${PN} += " \
     xen-tools-xenstore \
 "
 
+RRECOMMENDS_${PN} += " \
+    virtual/xenstored \
+"
+
 SRC_URI = " \
     git://github.com/xen-troops/snd_be.git;protocol=https;branch=yocto-v4.7.0-xt0.1 \
     file://sndbe.service \

--- a/meta-xt-driver-domain/recipes-extended/sndbe/sndbe_git.bb
+++ b/meta-xt-driver-domain/recipes-extended/sndbe/sndbe_git.bb
@@ -11,7 +11,11 @@ PACKAGECONFIG[alsa] = "-DWITH_ALSA=ON,-DWITH_ALSA=OFF,alsa-lib,alsa-server"
 
 DEPENDS = "libxenbe libconfig git-native"
 
-RDEPENDS_${PN} = "libxenbe libconfig"
+RDEPDENDS_${PN} += " \
+    libxenbe \
+    libconfig \
+    xen-tools-xenstore \
+"
 
 SRC_URI = " \
     git://github.com/xen-troops/snd_be.git;protocol=https;branch=yocto-v4.7.0-xt0.1 \

--- a/meta-xt-driver-domain/recipes-extended/virtio-disk/files/virtio-disk.service
+++ b/meta-xt-driver-domain/recipes-extended/virtio-disk/files/virtio-disk.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=virtio-disk backend
 Requires=proc-xen.mount
-After=proc-xen.mount
+Wants=xenstored.service
+After=proc-xen.mount xenstored.service
 
 [Service]
 Type=simple

--- a/meta-xt-driver-domain/recipes-extended/virtio-disk/virtio-disk.bb
+++ b/meta-xt-driver-domain/recipes-extended/virtio-disk/virtio-disk.bb
@@ -24,6 +24,10 @@ RDEPDENDS_${PN} += " \
     xen-tools-xenstore \
 "
 
+RRECOMMENDS_${PN} += " \
+    virtual/xenstored \
+"
+
 do_install_append() {
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/virtio-disk.service ${D}${systemd_system_unitdir}

--- a/meta-xt-driver-domain/recipes-extended/virtio-disk/virtio-disk.bb
+++ b/meta-xt-driver-domain/recipes-extended/virtio-disk/virtio-disk.bb
@@ -20,6 +20,10 @@ inherit systemd pkgconfig autotools-brokensep
 
 SYSTEMD_SERVICE_${PN} = "virtio-disk.service"
 
+RDEPDENDS_${PN} += " \
+    xen-tools-xenstore \
+"
+
 do_install_append() {
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/virtio-disk.service ${D}${systemd_system_unitdir}


### PR DESCRIPTION
Hello,

this pull request introduces both install and startup dependencies over xenstore for PV backends. This is needed for correct execution of the ExecStartPost, ExecPost and ExecStopPost actions declared inside the systemd services for the backends.

The issue that triggered the need for this pull request is a timed-out shutdown of the sndbe service due to the fact that the xenstored service was stopped before it (and thus both the ExecStop and ExecStopPost actions were failing).

Also, I'm pretty sure that after this modification the "ExecStartPre=/bin/sleep 1" line inside sndbe.serivce can be removed (but I'm not sure why it's there, so this is not performed in current pull request).