### PR TITLE
domd, displbe: change revision to master

### DIFF
--- a/meta-xt-driver-domain/recipes-extended/displbe/displbe_git.bb
+++ b/meta-xt-driver-domain/recipes-extended/displbe/displbe_git.bb
@@ -10,7 +10,7 @@ inherit pkgconfig cmake  systemd
 SYSTEMD_SERVICE_${PN} = "displbe.service"
 
 SRC_URI = " \
-    git://github.com/xen-troops/displ_be.git;protocol=https;branch=yocto-v4.7.0-xt0.1 \
+    git://github.com/xen-troops/displ_be.git;protocol=https;branch=master \
     file://displbe.service \
 "
 


### PR DESCRIPTION
The common product should use master as a
source branch for development.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>