### PR TITLE
domd: use PACKAGECONFIG whenever possible

### DIFF
--- a/meta-xt-driver-domain/recipes-extended/camerabe/camerabe_git.bb
+++ b/meta-xt-driver-domain/recipes-extended/camerabe/camerabe_git.bb
@@ -30,7 +30,8 @@ RRECOMMENDS_${PN} += " \
     virtual/xenstored \
 "
 
-EXTRA_OECMAKE_append_rcar = " -DWITH_DOC=OFF"
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[doc] = "-DWITH_DOC=ON,-DWITH_DOC=OFF,doxygen-native"
 
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/meta-xt-driver-domain/recipes-extended/displaymanager/displaymanager_git.bb
+++ b/meta-xt-driver-domain/recipes-extended/displaymanager/displaymanager_git.bb
@@ -20,7 +20,10 @@ SRC_URI = " \
 S = "${WORKDIR}/git"
 SRCREV = "${AUTOREV}"
 
-EXTRA_OECMAKE_append = " -DWITH_DOC=OFF -DCMAKE_BUILD_TYPE=Release"
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[doc] = "-DWITH_DOC=ON,-DWITH_DOC=OFF,doxygen-native"
+
+EXTRA_OECMAKE_append = " -DCMAKE_BUILD_TYPE=Release"
 
 do_install_append() {
     install -d ${D}${sysconfdir}/dbus-1/system.d

--- a/meta-xt-driver-domain/recipes-extended/displbe/displbe_git.bb
+++ b/meta-xt-driver-domain/recipes-extended/displbe/displbe_git.bb
@@ -18,9 +18,24 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=a23a74b3f4caf9616230789d94217acb"
 
 SRCREV = "${AUTOREV}"
 
-DEPENDS = "libxenbe libconfig libdrm wayland git-native wayland-ivi-extension wayland-native"
+DEPENDS = "libxenbe libconfig git-native"
 
-EXTRA_OECMAKE = " -DWITH_DOC=OFF -DWITH_DRM=ON -DWITH_ZCOPY=ON -DWITH_WAYLAND=ON -DWITH_IVI_EXTENSION=ON -DWITH_INPUT=ON"
+PACKAGECONFIG ??= "\
+    drm \
+    input \
+    zcopy zcopy-drm zcopy-kms zcopy-dmabuf \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'wayland wayland-ivi','', d)} \
+"
+
+PACKAGECONFIG[doc] = "-DWITH_DOC=ON,-DWITH_DOC=OFF,doxygen-native"
+PACKAGECONFIG[drm] = "-DWITH_DRM=ON,-DWITH_DRM=OFF,libdrm"
+PACKAGECONFIG[input] = "-DWITH_INPUT=ON,-DWITH_INPUT=OFF,"
+PACKAGECONFIG[wayland] = "-DWITH_WAYLAND=ON,-DWITH_WAYLAND=OFF,wayland wayland-native"
+PACKAGECONFIG[wayland-ivi] = "-DWITH_WAYLAND=ON -DWITH_IVI_EXTENSION=ON,-DWITH_WAYLAND=OFF -DWITH_IVI_EXTENSION=OFF,wayland wayland-native wayland-ivi-extension"
+PACKAGECONFIG[zcopy] = "-DWITH_ZCOPY=ON,-DWITH_ZCOPY=OFF,"
+PACKAGECONFIG[zcopy-drm] = "-DWITH_DRM_ZCOPY=ON,-DWITH_DRM_ZCOPY=OFF,"
+PACKAGECONFIG[zcopy-kms] = "-DWITH_KMS_ZCOPY=ON,-DWITH_KMS_ZCOPY=OFF,"
+PACKAGECONFIG[zcopy-dmabuf] = "-DWITH_DMABUF_ZCOPY=ON,-DWITH_DMABUF_ZCOPY=OFF,"
 
 RDEPDENDS_${PN} += " \
     xen-tools-xenstore \

--- a/meta-xt-driver-domain/recipes-extended/sndbe/sndbe_git.bb
+++ b/meta-xt-driver-domain/recipes-extended/sndbe/sndbe_git.bb
@@ -8,6 +8,7 @@ inherit pkgconfig cmake systemd
 PACKAGECONFIG ??= "${@bb.utils.filter('DISTRO_FEATURES', 'pulseaudio alsa', d)}"
 PACKAGECONFIG[pulseaudio] = "-DWITH_PULSE=ON,-DWITH_PULSE=OFF,pulseaudio,pulseaudio-server"
 PACKAGECONFIG[alsa] = "-DWITH_ALSA=ON,-DWITH_ALSA=OFF,alsa-lib,alsa-server"
+PACKAGECONFIG[doc] = "-DWITH_DOC=ON,-DWITH_DOC=OFF,doxygen-native"
 
 DEPENDS = "libxenbe libconfig git-native"
 
@@ -30,8 +31,6 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=a23a74b3f4caf9616230789d94217acb"
 S = "${WORKDIR}/git"
 
 SRCREV = "${AUTOREV}"
-
-EXTRA_OECMAKE = " -DWITH_DOC=OFF"
 
 SYSTEMD_SERVICE_${PN} = "sndbe.service"
 


### PR DESCRIPTION
Use PACKAGECONFIG mechanism whenever possible in meta-xt-control-domain, to simplify configuration done by platform-specific layers. Default PACKAGECONFIGs reflect previous static configuration.

It shall be noted that bbappends defined in layers building on top of this will work as before only if they uses `EXTRA_OECMAKE_append` to modify the EXTRA_OECMAKE variable, but will not work if they uses `EXTRA_OECMAKE +=` (as values coming from the PACKAGECONFIG mechanism will be appended).