### PR TITLE
dom0: handle absence of XT_DOMA_CONFIG_NAME

### DIFF
--- a/meta-xt-control-domain/recipes-guest/doma/doma.bb
+++ b/meta-xt-control-domain/recipes-guest/doma/doma.bb
@@ -13,9 +13,13 @@ EXTERNALSRC_SYMLINKS = ""
 RDEPENDS_${PN} = "u-boot-android"
 
 SRC_URI = "\
-    file://${XT_DOMA_CONFIG_NAME} \
     file://doma.service \
 "
+
+python () {
+    if d.getVar('XT_DOMA_CONFIG_NAME'):
+        d.appendVar('SRC_URI', ' file://${XT_DOMA_CONFIG_NAME} ')
+}
 
 FILES_${PN} = " \
     ${sysconfdir}/xen/doma.cfg \


### PR DESCRIPTION
If we do not use DomA then XT_DOMA_CONFIG_NAME is not defined.
This results in attempt to calculate CRC for incorrect file
`file://${XT_DOMA_CONFIG_NAME}` during parsing of recipes.

This commit fixes a warning that appears during parsing of
recipes if XT_DOMA_CONFIG_NAME is not defined.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>