### PR TITLE
Set priority of layers to 8

### DIFF
--- a/meta-xt-control-domain/conf/layer.conf
+++ b/meta-xt-control-domain/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "xt-control-domain"
 BBFILE_PATTERN_xt-control-domain := "^${LAYERDIR}/"
-BBFILE_PRIORITY_xt-control-domain = "6"
+BBFILE_PRIORITY_xt-control-domain = "8"
 
 LAYERSERIES_COMPAT_xt-control-domain = "dunfell"
 

--- a/meta-xt-dom0/conf/layer.conf
+++ b/meta-xt-dom0/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "xt-dom0"
 BBFILE_PATTERN_xt-dom0 := "^${LAYERDIR}/"
-BBFILE_PRIORITY_xt-dom0 = "6"
+BBFILE_PRIORITY_xt-dom0 = "8"
 
 LAYERSERIES_COMPAT_xt-dom0 = "dunfell"
 

--- a/meta-xt-domu/conf/layer.conf
+++ b/meta-xt-domu/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "xt-domu"
 BBFILE_PATTERN_xt-domu := "^${LAYERDIR}/"
-BBFILE_PRIORITY_xt-domu = "6"
+BBFILE_PRIORITY_xt-domu = "8"
 
 LAYERSERIES_COMPAT_xt-domu = "dunfell"
 

--- a/meta-xt-domx/conf/layer.conf
+++ b/meta-xt-domx/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "xt-domx"
 BBFILE_PATTERN_xt-domx := "^${LAYERDIR}/"
-BBFILE_PRIORITY_xt-domx = "6"
+BBFILE_PRIORITY_xt-domx = "8"
 
 LAYERSERIES_COMPAT_xt-domx = "dunfell"
 

--- a/meta-xt-driver-domain/conf/layer.conf
+++ b/meta-xt-driver-domain/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "xt-driver-domain"
 BBFILE_PATTERN_xt-driver-domain := "^${LAYERDIR}/"
-BBFILE_PRIORITY_xt-driver-domain = "6"
+BBFILE_PRIORITY_xt-driver-domain = "8"
 
 LAYERSERIES_COMPAT_xt-driver-domain = "dunfell"
 


### PR DESCRIPTION
To make sure that specific components can override/redefine settings from more generic levels, we set the following priorities for levels:

```
meta-xt-common     -  8
meta-xt-<platform> - 10
meta-xt-<product>  - 12
```

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>