### PR TITLE
Backporting useful changes from hardknott release MR

### DIFF
--- a/meta-xt-domx/recipes-extended/xen/xen-source.inc
+++ b/meta-xt-domx/recipes-extended/xen/xen-source.inc
@@ -1,9 +1,10 @@
 LIC_FILES_CHKSUM = "file://COPYING;md5=419739e325a50f3d7b4501338e44a4e5"
 
 XEN_URL ??= "git://github.com/xen-troops/xen.git;protocol=https;branch=xen-4.16rc-migration"
+XEN_REV ??= "${AUTOREV}"
 
 SRC_URI = "${XEN_URL}"
 XEN_REL = "4.16"
 PV = "${XEN_REL}.0+git${SRCPV}"
-SRCREV = "${AUTOREV}"
+SRCREV = "${XEN_REV}"
 

--- a/meta-xt-driver-domain/recipes-extended/displaymanager/displaymanager_git.bb
+++ b/meta-xt-driver-domain/recipes-extended/displaymanager/displaymanager_git.bb
@@ -10,10 +10,9 @@ SYSTEMD_SERVICE_${PN} = "display-manager.service"
 DEPENDS = "libconfig wayland-ivi-extension glib-2.0 glib-2.0-native git-native xt-log"
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
-RDEPENDS_${PN} += " dbus-cxx"
 
 SRC_URI = " \
-    git://github.com/xen-troops/DisplayManager.git;protocol=https;branch=yocto-v4.7.0-xt0.1 \
+    git://github.com/xen-troops/DisplayManager.git;protocol=https;branch=master \
     file://display_manager.conf \
     file://display-manager.service \
 "


### PR DESCRIPTION
This is the backport of the some useful patches from https://github.com/xen-troops/meta-xt-common/pull/31 MR, which adds hardknott release to meta-xt-common