### PR TITLE
[WIP] dbus-cxx: remove virtclass-native as outdated

### DIFF
--- a/meta-xt-domx/recipes-core/dbus/dbus-cxx_0.10.0.bb
+++ b/meta-xt-domx/recipes-core/dbus/dbus-cxx_0.10.0.bb
@@ -12,4 +12,3 @@ S = "${WORKDIR}/git"
 inherit autotools-brokensep pkgconfig
 
 BBCLASSEXTEND = "native"
-DEPENDS_virtclass-native = "dbus-native libsigc++-2.0-native"


### PR DESCRIPTION
The `virtclass-native` override has deprecated since 2012 and support has been removed since yocto 2.6.
On one side it could be better to replace it with the new override `class-native`.
But taking into account that we were fine with the absence of this dependency, I decided to remove it as not needed.