### PR TITLE
weston-init: remove ivi shell configuration as it is platform-specifiс

### DIFF
--- a/meta-xt-domx/recipes-graphics/wayland/weston-init.bbappend
+++ b/meta-xt-domx/recipes-graphics/wayland/weston-init.bbappend
@@ -3,21 +3,6 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 do_install:append() {
     if echo "${DISTRO_FEATURES}" | grep -q "ivi-shell"; then
-        sed -i '/\[core\]/c\\[core\]\nmodules=ivi-controller.so' \
-            ${D}/${sysconfdir}/xdg/weston/weston.ini
-        sed -e '$a\\' \
-            -e '$a\[ivi-shell]' \
-            -e '$a\ivi-module=ivi-controller.so' \
-            -e '$a\ivi-input-module=ivi-input-controller.so' \
-            -e '$a\ivi-id-agent-module=ivi-id-agent.so' \
-            -e '$a\transition-duration=300' \
-            -e '$a\cursor-theme=default' \
-            -i ${D}/${sysconfdir}/xdg/weston/weston.ini
-        sed -e '$a\\' \
-            -e '$a\[desktop-app-default]' \
-            -e '$a\default-surface-id=2000000' \
-            -e '$a\default-surface-id-max=2001000' \
-            -i ${D}/${sysconfdir}/xdg/weston/weston.ini
         sed -i '/repaint-window=*/c\repaint-window=8' \
             ${D}/${sysconfdir}/xdg/weston/weston.ini
     fi


### PR DESCRIPTION
weston-init: remove ivi shell configuration as it is platform-specifiс

IVI setting should be applied in hardware-specific or product layers,
but not in common code.