### PR TITLE
distro-features: Remove deps to displbe and sndbe

### DIFF
--- a/meta-xt-control-domain/recipes-guest/domu/files/domu.service
+++ b/meta-xt-control-domain/recipes-guest/domu/files/domu.service
@@ -1,7 +1,5 @@
 [Unit]
 Description=DomU
-Requires=backend-ready@displbe.service backend-ready@sndbe.service
-After=backend-ready@displbe.service backend-ready@sndbe.service
 
 [Service]
 Type=oneshot

--- a/meta-xt-driver-domain/recipes-graphics/images/core-image-weston.bbappend
+++ b/meta-xt-driver-domain/recipes-graphics/images/core-image-weston.bbappend
@@ -4,7 +4,6 @@ IMAGE_INSTALL:append = " \
     xen-tools-scripts-network \
     xen-tools-scripts-block \
     xen-tools-xenstore \
-    displbe \
     xen-network \
     dnsmasq \
     block \


### PR DESCRIPTION
The use-case appeared, for which we need to disable installation of the
displbe and sndbe services for a specific product.

For this purpose, we remove default installation of those services,
making it a product-specific decision on whether to install them or
not.

This patch is intended to remove dependencies to displbe and sndbe from
the common meta-layers.