### PR TITLE
u-boot: Switch virtio builds to origin Android U-boot

### DIFF
--- a/meta-xt-control-domain/recipes-guest/doma/doma.bb
+++ b/meta-xt-control-domain/recipes-guest/doma/doma.bb
@@ -10,7 +10,7 @@ inherit externalsrc systemd
 EXTERNALSRC_SYMLINKS = ""
 
 # We use custom U-BOOT to run the Android
-RDEPENDS:${PN} = "u-boot-android"
+RDEPENDS:${PN} = "${@bb.utils.contains('DISTRO_FEATURES', 'enable_virtio', ' u-boot-android-bazel', ' u-boot-android', d)}"
 
 SRC_URI = "\
     file://doma.service \

--- a/meta-xt-control-domain/recipes-guest/doma/u-boot-android-bazel_1.0.0.bb
+++ b/meta-xt-control-domain/recipes-guest/doma/u-boot-android-bazel_1.0.0.bb
@@ -1,0 +1,48 @@
+SUMMARY = "Deployment of Android U-Boot, which is built by the Bazel build system."
+DESCRIPTION = "Android U-Boot is a standard tool to boot Android."
+
+inherit base
+
+# PARAMETERS
+
+UBOOT_REPO_GIT_URL ?= "github.com/xen-troops/android_u-boot_manifest"
+UBOOT_REPO_DOWNLOAD_PROTOCOL ?= "https"
+UBOOT_REPO_GIT_BRANCH ?= "xenvm-trout-main"
+UBOOT_REPO_MANIFEST ?= "default.xml"
+U_BOOT_BUILD_TARGET ?= "xen-guest-android-virtio_aarch64"
+
+# IMPLEMENTATION
+
+SRC_URI = "\
+           repo://${UBOOT_REPO_GIT_URL};protocol=${UBOOT_REPO_DOWNLOAD_PROTOCOL};branch=${UBOOT_REPO_GIT_BRANCH};manifest=${UBOOT_REPO_MANIFEST}  \
+           "
+
+LICENSE = "GPLv2+"
+LIC_FILES_CHKSUM = "file://${WORKDIR}/repo/u-boot/Licenses/README;md5=2ca5f2c35c8cc335f0a19756634782f1"
+
+FILES:${PN} = "\
+               ${libdir}/xen/boot/u-boot-doma \
+               "
+
+do_compile() {
+    cd ${WORKDIR}/repo;
+    export CC=""
+    export CXX=""
+    export LD=""
+    export LDFLAGS=""
+    export CFLAGS=""
+    export CXXFLAGS=""
+    # Use it instead if you want to get more debug build artifacts.
+    # tools/bazel run //u-boot:${U_BOOT_BUILD_TARGET}_dist --verbose_failures --sandbox_debug -- --dist_dir=${B};
+    tools/bazel --max_idle_secs=1 run //u-boot:${U_BOOT_BUILD_TARGET}_dist -- --dist_dir=${B};
+    BUILD_RESULT=$(echo $?);
+    tools/bazel clean --expunge;
+    tools/bazel shutdown;
+    exit ${BUILD_RESULT};
+}
+
+do_install() {
+    install -d ${D}/${libdir}/xen/boot/
+    install -m 0644 ${B}/u-boot.bin \
+        ${D}/${libdir}/xen/boot/u-boot-doma
+}


### PR DESCRIPTION
For the virtio builds we want to use a recent origin Android U-Boot.

This patch introduces a u-boot-android-bazel.bb, which is used to build original Android U-Boot.