### PR TITLE
dom-0: implement support of empty dtb paths

### DIFF
--- a/meta-xt-control-domain/recipes-guest/doma/doma.bb
+++ b/meta-xt-control-domain/recipes-guest/doma/doma.bb
@@ -29,11 +29,19 @@ FILES:${PN} = " \
 
 SYSTEMD_SERVICE:${PN} = "doma.service"
 
+# Set path to dtb file to empty value in case it was not defined before.
+# In this case dtb will not be installed in 'do_install'.
+# This is usefull in case if precompiled dtb is not needed and only one
+# provided by xen will be used.
+XT_DOMA_DTB_NAME ??= ""
+
 do_install() {
     install -d ${D}${sysconfdir}/xen
     install -d ${D}${libdir}/xen/boot
     install -m 0644 ${WORKDIR}/${XT_DOMA_CONFIG_NAME} ${D}${sysconfdir}/xen/doma.cfg
-    install -m 0644 ${S}/${XT_DOMA_DTB_NAME} ${D}${libdir}/xen/boot/doma.dtb
+    if [ -n "${XT_DOMA_DTB_NAME}" ]; then
+        install -m 0644 ${S}/${XT_DOMA_DTB_NAME} ${D}${libdir}/xen/boot/doma.dtb
+    fi
 
     install -d ${D}${systemd_unitdir}/system
     install -m 0644 ${WORKDIR}/doma.service ${D}${systemd_unitdir}/system/

--- a/meta-xt-control-domain/recipes-guest/domu/domu.bb
+++ b/meta-xt-control-domain/recipes-guest/domu/domu.bb
@@ -24,11 +24,19 @@ FILES:${PN} = " \
 
 SYSTEMD_SERVICE:${PN} = "domu.service"
 
+# Set path to dtb file to empty value in case it was not defined before.
+# In this case dtb will not be installed in 'do_install'.
+# This is usefull in case if precompiled dtb is not needed and only one
+# provided by xen will be used.
+XT_DOMU_DTB_NAME ??= ""
+
 do_install() {
     install -d ${D}${sysconfdir}/xen
     install -d ${D}${libdir}/xen/boot
     install -m 0644 ${WORKDIR}/${XT_DOMU_CONFIG_NAME} ${D}${sysconfdir}/xen/domu.cfg
-    install -m 0644 ${S}/${XT_DOMU_DTB_NAME} ${D}${libdir}/xen/boot/domu.dtb
+    if [ -n "${XT_DOMU_DTB_NAME}" ]; then
+        install -m 0644 ${S}/${XT_DOMU_DTB_NAME} ${D}${libdir}/xen/boot/domu.dtb
+    fi
     install -m 0644 ${S}/Image ${D}${libdir}/xen/boot/linux-domu
 
     install -d ${D}${systemd_unitdir}/system


### PR DESCRIPTION
If dtb is not required for dom-u or dom-a corresponding variables 'XT_DOMU_DTB_NAME' or 'XT_DOMA_DTB_NAME' will not be defined in *.yaml configuration. In this case we should test content of these variables in recipe files where corresponding dtbs are installed to avoid their installation.