### PR TITLE
domz: fix usage of XT_DOMZ_CONFIG_NAME

### DIFF
--- a/meta-xt-control-domain/recipes-guest/domz/domz.bb
+++ b/meta-xt-control-domain/recipes-guest/domz/domz.bb
@@ -10,9 +10,13 @@ inherit systemd
 EXTERNALSRC_SYMLINKS = ""
 
 SRC_URI = "\
-    file://${XT_DOMZ_CONFIG_NAME} \
     file://domz.service \
 "
+
+python () {
+    if d.getVar('XT_DOMZ_CONFIG_NAME'):
+        d.appendVar('SRC_URI', ' file://${XT_DOMZ_CONFIG_NAME}')
+}
 
 FILES_${PN} = " \
     ${sysconfdir}/xen/domz.cfg \


### PR DESCRIPTION
Variable XT_DOMZ_CONFIG_NAME is not defined if Zephyr is not used as guest.
For that reason we have to add XT_DOMZ_CONFIG_NAME to SRC_URI conditionaly, to avoid warning during parsing of recipes.