### PR TITLE
[Port to master] xen-network: wait for network.target

### DIFF
--- a/meta-xt-driver-domain/recipes-connectivity/xen-network/files/bridge-up-notification.service
+++ b/meta-xt-driver-domain/recipes-connectivity/xen-network/files/bridge-up-notification.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Bridge up notification
-Wants=systemd-networkd-wait-online.service xenstored.service
-After=systemd-networkd-wait-online.service xenstored.service
+Wants=xenstored.service
+After=xenstored.service network.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
This commit is cherry-picked as-is from the `dunfell` branch with `Acked-by`.

---

This commit makes `bridge-up-notification` dependant on `network.target` instead of `networkd-wait-online.service`. That change allows to run bridge when network management stack is up, and avoid situation when guest domain is not starting because network is not connected or not configured properly.

According to the documentation, we should use just `After=network.target`, because this is a passive unit.


Acked-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>