### PR TITLE
doma: update manifest branch with xen-troops based u-boot

### DIFF
--- a/meta-xt-control-domain/recipes-guest/doma/u-boot-android-bazel_1.0.0.bb
+++ b/meta-xt-control-domain/recipes-guest/doma/u-boot-android-bazel_1.0.0.bb
@@ -7,7 +7,7 @@ inherit base
 
 UBOOT_REPO_GIT_URL ?= "github.com/xen-troops/android_u-boot_manifest"
 UBOOT_REPO_DOWNLOAD_PROTOCOL ?= "https"
-UBOOT_REPO_GIT_BRANCH ?= "u-boot-mainline-xt-30_08_23"
+UBOOT_REPO_GIT_BRANCH ?= "u-boot-mainline-xt"
 UBOOT_REPO_MANIFEST ?= "default.xml"
 U_BOOT_BUILD_TARGET ?= "xen_aarch64"
 


### PR DESCRIPTION
Transition U-Boot to the xen-troops repository is
required to facilitate the implementation of virtio blk. This is necessitated by the absence of two crucial patches in the Android repository. The switch will be in effect until full upstream integration is achieved.