### PR TITLE
dom0: handle absence of XT_DOMU_CONFIG_NAME

### DIFF
--- a/meta-xt-control-domain/recipes-guest/domu/domu.bb
+++ b/meta-xt-control-domain/recipes-guest/domu/domu.bb
@@ -10,10 +10,14 @@ inherit externalsrc systemd
 EXTERNALSRC_SYMLINKS = ""
 
 SRC_URI = "\
-    file://${XT_DOMU_CONFIG_NAME} \
     file://domu-vdevices.cfg \
     file://domu.service \
 "
+
+python () {
+    if d.getVar('XT_DOMU_CONFIG_NAME'):
+        d.appendVar('SRC_URI', ' file://${XT_DOMU_CONFIG_NAME}')
+}
 
 FILES:${PN} = " \
     ${sysconfdir}/xen/domu.cfg \


### PR DESCRIPTION
If we do not use DomU then XT_DOMU_CONFIG_NAME is not defined. This results in attempt to calculate CRC for incorrect file `file://${XT_DOMU_CONFIG_NAME}` during parsing of recipes.

This commit fixes a warning that appears during parsing of recipes if XT_DOMU_CONFIG_NAME is not defined.