### PR TITLE
doma: choose U-Boot config with respect to build type

### DIFF
--- a/meta-xt-control-domain/recipes-guest/doma/u-boot-android-bazel_1.0.0.bb
+++ b/meta-xt-control-domain/recipes-guest/doma/u-boot-android-bazel_1.0.0.bb
@@ -9,7 +9,7 @@ UBOOT_REPO_GIT_URL ?= "github.com/xen-troops/android_u-boot_manifest"
 UBOOT_REPO_DOWNLOAD_PROTOCOL ?= "https"
 UBOOT_REPO_GIT_BRANCH ?= "u-boot-mainline-xt"
 UBOOT_REPO_MANIFEST ?= "default.xml"
-U_BOOT_BUILD_TARGET ?= "xen_aarch64"
+U_BOOT_BUILD_TARGET ?= "${@bb.utils.contains('DISTRO_FEATURES', 'enable_virtio', 'xen_aarch64', 'xen_pvblock_aarch64', d)}"
 
 SRC_URI:append = "file://0001-xenvm-do-not-use-persistent-storage-for-bootconfig.patch;patchdir=${WORKDIR}/repo/u-boot"
 


### PR DESCRIPTION
In the case of a virtio build, the configuration for virtio-blk will be chosen. In other cases, the configuration for pvblock will be chosen.