### PR TITLE
xen-network.bb: don't use "\n" in echo command

### DIFF
--- a/meta-xt-driver-domain/recipes-connectivity/xen-network/xen-network.bb
+++ b/meta-xt-driver-domain/recipes-connectivity/xen-network/xen-network.bb
@@ -56,7 +56,7 @@ do_install() {
     install -m 0644 ${S}/xenbr0-systemd-networkd.conf ${D}${sysconfdir}/systemd/system/systemd-networkd.service.d
     install -m 0644 ${S}/port-forward-systemd-networkd.conf ${D}${sysconfdir}/systemd/system/systemd-networkd.service.d
     if ${@bb.utils.contains('XT_GUEST_INSTALL', 'domf', 'true', 'false', d)}; then
-        echo "\n# SSH to domF" \
+        echo "# SSH to domF" \
             >> ${D}${sysconfdir}/systemd/system/systemd-networkd.service.d/port-forward-systemd-networkd.conf
         echo "ExecStartPost=+/usr/sbin/iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 2022 -j DNAT --to-destination 192.168.0.3:22" \
             >> ${D}${sysconfdir}/systemd/system/systemd-networkd.service.d/port-forward-systemd-networkd.conf
@@ -64,13 +64,13 @@ do_install() {
             >> ${D}${sysconfdir}/systemd/system/systemd-networkd.service.d/port-forward-systemd-networkd.conf
     fi
     if ${@bb.utils.contains('XT_GUEST_INSTALL', 'doma', 'true', 'false', d)}; then
-        echo "\n# ADB to domA" \
+        echo "# ADB to domA" \
             >> ${D}${sysconfdir}/systemd/system/systemd-networkd.service.d/port-forward-systemd-networkd.conf
         echo "ExecStartPost=+/usr/sbin/iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 5555 -j DNAT --to-destination 192.168.0.4:5555" \
             >> ${D}${sysconfdir}/systemd/system/systemd-networkd.service.d/port-forward-systemd-networkd.conf
     fi
     if ${@bb.utils.contains('XT_GUEST_INSTALL', 'domu', 'true', 'false', d)}; then
-        echo "\n# SSH to domU" \
+        echo "# SSH to domU" \
             >> ${D}${sysconfdir}/systemd/system/systemd-networkd.service.d/port-forward-systemd-networkd.conf
         echo "ExecStartPost=+/usr/sbin/iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 2025 -j DNAT --to-destination 192.168.0.5:22" \
             >> ${D}${sysconfdir}/systemd/system/systemd-networkd.service.d/port-forward-systemd-networkd.conf


### PR DESCRIPTION
"\n" handling is wildly varies between shells. Some shells replace it with line feed, other just print it as is (i.e. literally \n). This causes hard to debug issues with the build. This particular case led to the following error:

```
ERROR: Logfile of failure stored in: /home/lorc/work/prod-devel-salvator-8g/yocto/build-domd/tmp/work/salvator_x-poky-linux/core-image-weston/1.0-r0/temp/log.do_image.1535569
Log data follows:
| DEBUG: Executing python function do_image
| NOTE: Executing systemd_preset_all ...
| DEBUG: Executing shell function systemd_preset_all
| ln -s /lib/systemd/system/systemd-userdbd.socket /home/lorc/work/prod-devel-salvator-8g/yocto/build-domd/tmp/work/salvator_x-poky-linux/core-image-weston/1.0-r0/rootfs/etc/systemd/system/so
ckets.target.wants/systemd-userdbd.socket
| ln -s /lib/systemd/system/systemd-timesyncd.service /home/lorc/work/prod-devel-salvator-8g/yocto/build-domd/tmp/work/salvator_x-poky-linux/core-image-weston/1.0-r0/rootfs/etc/systemd/system
/sysinit.target.wants/systemd-timesyncd.service
| ln -s /lib/systemd/system/systemd-timesyncd.service /home/lorc/work/prod-devel-salvator-8g/yocto/build-domd/tmp/work/salvator_x-poky-linux/core-image-weston/1.0-r0/rootfs/etc/systemd/system
/dbus-org.freedesktop.timesync1.service
| Traceback (most recent call last):
|   File "/home/lorc/work/prod-devel-salvator-8g/yocto/build-domd/tmp/work/salvator_x-poky-linux/core-image-weston/1.0-r0/recipe-sysroot-native/usr/bin/systemctl", line 350, in <module>
|     main()
|   File "/home/lorc/work/prod-devel-salvator-8g/yocto/build-domd/tmp/work/salvator_x-poky-linux/core-image-weston/1.0-r0/recipe-sysroot-native/usr/bin/systemctl", line 344, in main
|     preset_all(root)
|   File "/home/lorc/work/prod-devel-salvator-8g/yocto/build-domd/tmp/work/salvator_x-poky-linux/core-image-weston/1.0-r0/recipe-sysroot-native/usr/bin/systemctl", line 285, in preset_all
|     SystemdUnit(root, service).enable()
|   File "/home/lorc/work/prod-devel-salvator-8g/yocto/build-domd/tmp/work/salvator_x-poky-linux/core-image-weston/1.0-r0/recipe-sysroot-native/usr/bin/systemctl", line 221, in enable
|     config = SystemdFile(self.root, path, instance_unit_name)
|   File "/home/lorc/work/prod-devel-salvator-8g/yocto/build-domd/tmp/work/salvator_x-poky-linux/core-image-weston/1.0-r0/recipe-sysroot-native/usr/bin/systemctl", line 39, in __init__
|     self._parse(root, path2)
|   File "/home/lorc/work/prod-devel-salvator-8g/yocto/build-domd/tmp/work/salvator_x-poky-linux/core-image-weston/1.0-r0/recipe-sysroot-native/usr/bin/systemctl", line 79, in _parse
|     k = m.group('key')
| AttributeError: 'NoneType' object has no attribute 'group'
| WARNING: /home/lorc/work/prod-devel-salvator-8g/yocto/build-domd/tmp/work/salvator_x-poky-linux/core-image-weston/1.0-r0/temp/run.systemd_preset_all.1535569:150 exit 1 from 'systemctl --roo
t="/home/lorc/work/prod-devel-salvator-8g/yocto/build-domd/tmp/work/salvator_x-poky-linux/core-image-weston/1.0-r0/rootfs" --preset-mode=enable-only preset-all'
| WARNING: Backtrace (BB generated script):
|       #1: systemd_preset_all, /home/lorc/work/prod-devel-salvator-8g/yocto/build-domd/tmp/work/salvator_x-poky-linux/core-image-weston/1.0-r0/temp/run.systemd_preset_all.1535569, line 150
|       #2: main, /home/lorc/work/prod-devel-salvator-8g/yocto/build-domd/tmp/work/salvator_x-poky-linux/core-image-weston/1.0-r0/temp/run.systemd_preset_all.1535569, line 154
| DEBUG: Python function do_image finished
ERROR: Task (/home/lorc/work/prod-devel-salvator-8g/yocto/poky/meta/recipes-graphics/images/core-image-weston.bb:do_image) failed with exit code '1'
NOTE: Tasks Summary: Attempted 4718 tasks of which 4316 didn't need to be rerun and 1 failed.
```

From this error message it is unclear what exactly caused the error. It was found that Yocto script that emulates systemctl command was not ready to see "\n" sequence in a systemd unit file.

To fix this issue we just remote "\n" from the "echo" command. This will decrease readability of the resulting .service file a bit. Other alternatives are to use empty echo "" command or use "printf" command that correctly handles "\n" sequence across all shells. But both those options will impair readability in .bb file, so I prefer the first solution.