### PR TITLE
virtio-disk: Use proper branch for the backend

### DIFF
--- a/meta-xt-driver-domain/recipes-extended/virtio-disk/virtio-disk.bb
+++ b/meta-xt-driver-domain/recipes-extended/virtio-disk/virtio-disk.bb
@@ -12,7 +12,7 @@ DEPENDS = "xen-tools"
 SRCREV = "${AUTOREV}"
 
 SRC_URI:append = " \
-    git://github.com/xen-troops/virtio-disk.git;protocol=https;branch=ioreq_ml3 \
+    git://github.com/xen-troops/virtio-disk.git;protocol=https;branch=virtio_next \
     file://virtio-disk.service \
 "
 


### PR DESCRIPTION
Although the virtio-disk is not fully integrated, there is already recipe which allows to build the backend, so correct it to point to actual sources.