### PR TITLE
domd: domu: add support for core-image-minimal

### DIFF
--- a/meta-xt-domu/recipes-core/images/common_install.inc
+++ b/meta-xt-domu/recipes-core/images/common_install.inc
@@ -1,0 +1,1 @@
+IMAGE_INSTALL:append = " domu-network"

--- a/meta-xt-domu/recipes-core/images/core-image-minimal.bbappend
+++ b/meta-xt-domu/recipes-core/images/core-image-minimal.bbappend
@@ -1,0 +1,1 @@
+require common_install.inc

--- a/meta-xt-domu/recipes-graphics/images/core-image-weston.bbappend
+++ b/meta-xt-domu/recipes-graphics/images/core-image-weston.bbappend
@@ -1,1 +1,1 @@
-IMAGE_INSTALL:append = " domu-network"
+require recipes-core/images/common_install.inc

--- a/meta-xt-driver-domain/recipes-core/images/common_install.inc
+++ b/meta-xt-driver-domain/recipes-core/images/common_install.inc
@@ -1,0 +1,10 @@
+IMAGE_INSTALL:append = " \
+    xen \
+    xen-tools-devd \
+    xen-tools-scripts-network \
+    xen-tools-scripts-block \
+    xen-tools-xenstore \
+    xen-network \
+    dnsmasq \
+    block \
+"

--- a/meta-xt-driver-domain/recipes-core/images/core-image-minimal.bbappend
+++ b/meta-xt-driver-domain/recipes-core/images/core-image-minimal.bbappend
@@ -1,0 +1,1 @@
+require common_install.inc

--- a/meta-xt-driver-domain/recipes-graphics/images/core-image-weston.bbappend
+++ b/meta-xt-driver-domain/recipes-graphics/images/core-image-weston.bbappend
@@ -1,11 +1,5 @@
+require recipes-core/images/common_install.inc
+
 IMAGE_INSTALL:append = " \
-    xen \
-    xen-tools-devd \
-    xen-tools-scripts-network \
-    xen-tools-scripts-block \
-    xen-tools-xenstore \
-    xen-network \
-    dnsmasq \
-    block \
     ${@bb.utils.contains('DISTRO_FEATURES', 'ivi-shell', 'displaymanager', '', d)} \
 "


### PR DESCRIPTION
This commit adds possibility to build our components inside core-image-minimal.
Parts that are common for core-image-minimal and core-image-weston are moved into the common_install.inc file.