### PR TITLE
Add possibility to run virtio without weston

### DIFF
--- a/meta-xt-control-domain-virtio/recipes-guest/domu/domu.bbappend
+++ b/meta-xt-control-domain-virtio/recipes-guest/domu/domu.bbappend
@@ -3,6 +3,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SRC_URI += "\
     file://virtio-env.conf \
     file://virtio-env-weston.conf \
+    file://virtio-env-no-weston.conf \
 "
 
 RDEPENDS:${PN} += " \
@@ -11,7 +12,9 @@ RDEPENDS:${PN} += " \
 
 FILES:${PN} += " \
     ${sysconfdir}/systemd/system/domu.service.d/virtio-env.conf \
-    ${@bb.utils.contains('MACHINE_FEATURES', 'gsx', '${sysconfdir}/systemd/system/domu.service.d/virtio-env-weston.conf', '', d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'gsx', \
+        '${sysconfdir}/systemd/system/domu.service.d/virtio-env-weston.conf', \
+        '${sysconfdir}/systemd/system/domu.service.d/virtio-env-no-weston.conf', d)} \
 "
 
 do_install:append() {
@@ -23,5 +26,7 @@ do_install:append() {
     # we can look on presence of GSX on the board.
     if ${@bb.utils.contains('MACHINE_FEATURES', 'gsx', 'true', 'false', d)}; then
         install -m 0644 ${WORKDIR}/virtio-env-weston.conf ${D}${sysconfdir}/systemd/system/domu.service.d
+    else
+        install -m 0644 ${WORKDIR}/virtio-env-no-weston.conf ${D}${sysconfdir}/systemd/system/domu.service.d
     fi
 }

--- a/meta-xt-control-domain-virtio/recipes-guest/domu/domu.bbappend
+++ b/meta-xt-control-domain-virtio/recipes-guest/domu/domu.bbappend
@@ -2,6 +2,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += "\
     file://virtio-env.conf \
+    file://virtio-env-weston.conf \
 "
 
 RDEPENDS:${PN} += " \
@@ -10,9 +11,17 @@ RDEPENDS:${PN} += " \
 
 FILES:${PN} += " \
     ${sysconfdir}/systemd/system/domu.service.d/virtio-env.conf \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'gsx', '${sysconfdir}/systemd/system/domu.service.d/virtio-env-weston.conf', '', d)} \
 "
 
 do_install:append() {
     install -d ${D}${sysconfdir}/systemd/system/domu.service.d
     install -m 0644 ${WORKDIR}/virtio-env.conf ${D}${sysconfdir}/systemd/system/domu.service.d
+
+    # this virtio-env-weston.conf whould be used if we have the 'wayland'
+    # distro feature inside DomU. But to avoid introducing new variable
+    # we can look on presence of GSX on the board.
+    if ${@bb.utils.contains('MACHINE_FEATURES', 'gsx', 'true', 'false', d)}; then
+        install -m 0644 ${WORKDIR}/virtio-env-weston.conf ${D}${sysconfdir}/systemd/system/domu.service.d
+    fi
 }

--- a/meta-xt-control-domain-virtio/recipes-guest/domu/files/virtio-env-no-weston.conf
+++ b/meta-xt-control-domain-virtio/recipes-guest/domu/files/virtio-env-no-weston.conf
@@ -1,0 +1,3 @@
+[Unit]
+Requires=backend-ready@bridge.service
+After=backend-ready@bridge.service

--- a/meta-xt-control-domain-virtio/recipes-guest/domu/files/virtio-env-weston.conf
+++ b/meta-xt-control-domain-virtio/recipes-guest/domu/files/virtio-env-weston.conf
@@ -1,0 +1,3 @@
+[Unit]
+Requires=backend-ready@weston-up.service
+After=backend-ready@weston-up.service

--- a/meta-xt-control-domain-virtio/recipes-guest/domu/files/virtio-env.conf
+++ b/meta-xt-control-domain-virtio/recipes-guest/domu/files/virtio-env.conf
@@ -1,7 +1,3 @@
-[Unit]
-Requires=backend-ready@weston-up.service
-After=backend-ready@weston-up.service
-
 [Service]
 Type=simple
 ExecStart=

--- a/meta-xt-driver-domain-virtio/recipes-extended/xen/xen-tools_git.bbappend
+++ b/meta-xt-driver-domain-virtio/recipes-extended/xen/xen-tools_git.bbappend
@@ -1,12 +1,14 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 FILES:${PN}-devd += " \
-${sysconfdir}/systemd/system/xendriverdomain.service.d/weston-env.conf \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', '${sysconfdir}/systemd/system/xendriverdomain.service.d/weston-env.conf', '', d)} \
 "
 
 do_install:append() {
-    install -d ${D}${sysconfdir}/systemd/system/xendriverdomain.service.d
-    install -m 0644 ${WORKDIR}/weston-env.conf ${D}${sysconfdir}/systemd/system/xendriverdomain.service.d
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'true', 'false', d)}; then
+        install -d ${D}${sysconfdir}/systemd/system/xendriverdomain.service.d
+        install -m 0644 ${WORKDIR}/weston-env.conf ${D}${sysconfdir}/systemd/system/xendriverdomain.service.d
+    fi
 }
 
 SRC_URI += "\


### PR DESCRIPTION
- dom0: virtio: use weston-up as an optional drop-in for DomU
- dom0: virtio: add dependency for no wayland use case in DomU
- domd: virtio: install weston-env.conf optionally

This PR have to be merged only after https://github.com/xen-troops/meta-xt-prod-devel-rcar/pull/126 because we need
`gsx` MACHINE_FEATURE to be defined in Dom0.