### PR TITLE
Fix SRCREV for all components

### DIFF
--- a/meta-xt-control-domain/recipes-guest/doma/u-boot-android-bazel_1.0.0.bb
+++ b/meta-xt-control-domain/recipes-guest/doma/u-boot-android-bazel_1.0.0.bb
@@ -20,6 +20,7 @@ DEPENDS += "rsync-native"
 SRC_URI = "\
            repo://${UBOOT_REPO_GIT_URL};protocol=${UBOOT_REPO_DOWNLOAD_PROTOCOL};branch=${UBOOT_REPO_GIT_BRANCH};manifest=${UBOOT_REPO_MANIFEST}  \
            "
+SRCREV = "30adce0c709887d9788f33b494ae79090b8bcc17"
 
 LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://${WORKDIR}/repo/u-boot/Licenses/README;md5=2ca5f2c35c8cc335f0a19756634782f1"

--- a/meta-xt-domx/recipes-core/dbus/dbus-cxx_0.10.0.bb
+++ b/meta-xt-domx/recipes-core/dbus/dbus-cxx_0.10.0.bb
@@ -6,8 +6,10 @@ DEPENDS = "boost dbus libsigc++-2.0"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
-SRC_URI = "git://github.com/dbus-cxx/${PN}.git;nobranch=1;tag=${PV};protocol=https"
+SRC_URI = "git://github.com/dbus-cxx/${PN}.git;nobranch=1;protocol=https"
 S = "${WORKDIR}/git"
+# commit corresponds to tag '0.10.0'
+SRCREV = "1d9425027860d5b9006178aefc2e638c48848477"
 
 inherit autotools-brokensep pkgconfig
 

--- a/meta-xt-domx/recipes-extended/xen/xen-source.inc
+++ b/meta-xt-domx/recipes-extended/xen/xen-source.inc
@@ -1,7 +1,7 @@
 LIC_FILES_CHKSUM = "file://COPYING;md5=419739e325a50f3d7b4501338e44a4e5"
 
 XEN_URL ??= "git://github.com/xen-troops/xen.git;protocol=https;branch=xen-4.16rc-migration"
-XEN_REV ??= "${AUTOREV}"
+XEN_REV ??= "81ac624282e6ab429dfdb858da8360faf45ca8d7"
 
 SRC_URI = "${XEN_URL}"
 XEN_REL = "4.16"

--- a/meta-xt-driver-domain/recipes-extended/camerabe/camerabe_git.bb
+++ b/meta-xt-driver-domain/recipes-extended/camerabe/camerabe_git.bb
@@ -20,7 +20,7 @@ SRC_URI = " \
     file://camera_be.cfg \
 "
 
-SRCREV = "${AUTOREV}"
+SRCREV = "b12d4934b7d3fed75d1255793893070768636555"
 
 RDEPENDS:${PN} += " \
     xen-tools-xenstore \

--- a/meta-xt-driver-domain/recipes-extended/displaymanager/displaymanager_git.bb
+++ b/meta-xt-driver-domain/recipes-extended/displaymanager/displaymanager_git.bb
@@ -17,7 +17,7 @@ SRC_URI = " \
     file://display-manager.service \
 "
 S = "${WORKDIR}/git"
-SRCREV = "${AUTOREV}"
+SRCREV = "868e703b7652c9a40ae878d7d517f97398b4549c"
 
 PACKAGECONFIG ??= ""
 PACKAGECONFIG[doc] = "-DWITH_DOC=ON,-DWITH_DOC=OFF,doxygen-native"

--- a/meta-xt-driver-domain/recipes-extended/displbe/displbe_git.bb
+++ b/meta-xt-driver-domain/recipes-extended/displbe/displbe_git.bb
@@ -16,7 +16,7 @@ SRC_URI = " \
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=a23a74b3f4caf9616230789d94217acb"
 
-SRCREV = "${AUTOREV}"
+SRCREV = "b218acf44e71c4a77082944e3878e1859a352fba"
 
 DEPENDS = "libxenbe libconfig git-native"
 

--- a/meta-xt-driver-domain/recipes-extended/libxenbe/libxenbe_git.bb
+++ b/meta-xt-driver-domain/recipes-extended/libxenbe/libxenbe_git.bb
@@ -4,7 +4,7 @@ LICENSE = "GPL-2.0-only"
 PR = "r0"
 
 SRC_URI = "git://github.com/xen-troops/libxenbe.git;protocol=https;branch=master"
-SRCREV = "${AUTOREV}"
+SRCREV = "21f1fdc090ee5342df7608358c5130a7675dad68"
 
 DEPENDS = "xen-tools"
 RDEPENDS:${PN} = " \

--- a/meta-xt-driver-domain/recipes-extended/sndbe/sndbe_git.bb
+++ b/meta-xt-driver-domain/recipes-extended/sndbe/sndbe_git.bb
@@ -23,14 +23,14 @@ RRECOMMENDS:${PN} += " \
 "
 
 SRC_URI = " \
-    git://github.com/xen-troops/snd_be.git;protocol=https;branch=yocto-v4.7.0-xt0.1 \
+    git://github.com/xen-troops/snd_be.git;protocol=https;branch=master \
     file://sndbe.service \
 "
 LIC_FILES_CHKSUM = "file://LICENSE;md5=a23a74b3f4caf9616230789d94217acb"
 
 S = "${WORKDIR}/git"
 
-SRCREV = "${AUTOREV}"
+SRCREV = "b2764c2849f02c051f1d16dc6b592da59d1675c1"
 
 SYSTEMD_SERVICE:${PN} = "sndbe.service"
 

--- a/meta-xt-driver-domain/recipes-extended/virtio-disk/virtio-disk.bb
+++ b/meta-xt-driver-domain/recipes-extended/virtio-disk/virtio-disk.bb
@@ -9,7 +9,7 @@ S = "${WORKDIR}/git"
 
 DEPENDS = "xen-tools"
 
-SRCREV = "${AUTOREV}"
+SRCREV = "274f5e933a7381a9eb2a7b5856f37c3d982f3874"
 
 SRC_URI:append = " \
     git://github.com/xen-troops/virtio-disk.git;protocol=https;branch=virtio_next \

--- a/meta-xt-driver-domain/recipes-extended/xt-log/xt-log_git.bb
+++ b/meta-xt-driver-domain/recipes-extended/xt-log/xt-log_git.bb
@@ -3,8 +3,8 @@ SECTION = "libs"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-SRC_URI = "git://github.com/xen-troops/${BPN}.git;protocol=https;branch=yocto-v4.7.0-xt0.1"
-SRCREV = "${AUTOREV}"
+SRC_URI = "git://github.com/xen-troops/${BPN}.git;protocol=https;branch=master"
+SRCREV = "a88163b7f64c4eec4f7362ba33ecd55bd3dd1cdb"
 
 S = "${WORKDIR}/git"
 

--- a/meta-xt-qemu/recipes-qemu/qemu/qemu.inc
+++ b/meta-xt-qemu/recipes-qemu/qemu/qemu.inc
@@ -18,7 +18,7 @@ SRC_URI = "gitsm://github.com/xen-troops/qemu.git;branch=v7.0.0-xt;protocol=http
            file://powerpc_rom.bin \
            file://run-ptest \
            "
-SRCREV = "${AUTOREV}"
+SRCREV = "5456c82c966570c1a64524cd3fb7116d80199500"
 S = "${WORKDIR}/git"
 
 # UPSTREAM_CHECK_REGEX = "qemu-(?P<pver>\d+(\.\d+)+)\.tar"


### PR DESCRIPTION
- SRCREV is fixed for all components
- 'tag' is replaced with SRCREV for dbus-cxx to have consistent approach
- SRCREV is added for the android_u-boot_manifest repo