### PR TITLE
meta-xt-security: introduce the layer / add OP-TEE recipes

### DIFF
--- a/meta-xt-security/conf/layer.conf
+++ b/meta-xt-security/conf/layer.conf
@@ -1,0 +1,13 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have a packages directory, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "xt-security"
+BBFILE_PATTERN_xt-security := "^${LAYERDIR}/"
+BBFILE_PRIORITY_xt-security = "8"
+
+LAYERSERIES_COMPAT_xt-security = "kirkstone"
+

--- a/meta-xt-security/recipes-security/optee/optee-client.inc
+++ b/meta-xt-security/recipes-security/optee/optee-client.inc
@@ -1,0 +1,40 @@
+SUMMARY = "OP-TEE Client API"
+DESCRIPTION = "Open Portable Trusted Execution Environment - Normal World Client side of the TEE"
+HOMEPAGE = "https://www.op-tee.org/"
+
+LICENSE = "BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=69663ab153298557a59c67a60a743e5b"
+
+inherit systemd update-rc.d cmake
+
+SRC_URI = " \
+    git://github.com/OP-TEE/optee_client.git;branch=master;protocol=https \
+    file://tee-supplicant@.service \
+    file://tee-supplicant.sh \
+"
+
+UPSTREAM_CHECK_GITTAGREGEX = "^(?P<pver>\d+(\.\d+)+)$"
+
+S = "${WORKDIR}/git"
+
+EXTRA_OECMAKE = " \
+    -DBUILD_SHARED_LIBS=ON \
+    -DCFG_TEE_FS_PARENT_PATH='${localstatedir}/lib/tee' \
+"
+EXTRA_OECMAKE:append:toolchain-clang = " -DCFG_WERROR=0"
+
+do_install:append() {
+    install -D -p -m0644 ${WORKDIR}/tee-supplicant@.service ${D}${systemd_system_unitdir}/tee-supplicant@.service
+    install -D -p -m0755 ${WORKDIR}/tee-supplicant.sh ${D}${sysconfdir}/init.d/tee-supplicant
+
+    sed -i -e s:@sysconfdir@:${sysconfdir}:g \
+           -e s:@sbindir@:${sbindir}:g \
+              ${D}${systemd_system_unitdir}/tee-supplicant@.service \
+              ${D}${sysconfdir}/init.d/tee-supplicant
+}
+
+SYSTEMD_SERVICE:${PN} = "tee-supplicant@.service"
+
+INITSCRIPT_PACKAGES = "${PN}"
+INITSCRIPT_NAME:${PN} = "tee-supplicant"
+INITSCRIPT_PARAMS:${PN} = "start 10 1 2 3 4 5 . stop 90 0 6 ."

--- a/meta-xt-security/recipes-security/optee/optee-client/tee-supplicant.sh
+++ b/meta-xt-security/recipes-security/optee/optee-client/tee-supplicant.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+# Source function library
+. /etc/init.d/functions
+
+NAME=tee-supplicant
+PATH=/sbin:/bin:/usr/sbin:/usr/bin
+DESC="OP-TEE Supplicant"
+
+DAEMON=@sbindir@/$NAME
+
+test -f $DAEMON || exit 0
+
+test -f @sysconfdir@/default/$NAME && . @sysconfdir@/default/$NAME
+test -f @sysconfdir@/default/rcS && . @sysconfdir@/default/rcS
+
+SSD_OPTIONS="--oknodo --quiet --exec $DAEMON -- -d $OPTARGS"
+
+set -e
+
+case $1 in
+    start)
+	    echo -n "Starting $DESC: "
+	    start-stop-daemon --start $SSD_OPTIONS
+        echo "${DAEMON##*/}."
+        ;;
+    stop)
+	    echo -n "Stopping $DESC: "
+	    start-stop-daemon --stop $SSD_OPTIONS
+        echo "${DAEMON##*/}."
+        ;;
+    restart|force-reload)
+	    $0 stop
+	    sleep 1
+	    $0 start
+        ;;
+    status)
+        status ${DAEMON} || exit $?
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart|force-reload|status}" >&2
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/meta-xt-security/recipes-security/optee/optee-client/tee-supplicant@.service
+++ b/meta-xt-security/recipes-security/optee/optee-client/tee-supplicant@.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=TEE Supplicant on %i
+
+[Service]
+User=root
+EnvironmentFile=-@sysconfdir@/default/tee-supplicant
+ExecStart=@sbindir@/tee-supplicant $OPTARGS
+
+[Install]
+WantedBy=basic.target

--- a/meta-xt-security/recipes-security/optee/optee-client_4.1.0.bb
+++ b/meta-xt-security/recipes-security/optee/optee-client_4.1.0.bb
@@ -1,0 +1,7 @@
+require recipes-security/optee/optee-client.inc
+
+SRCREV = "f7e4ced15d1fefd073bbfc484fe0e1f74afe96c2"
+
+inherit pkgconfig
+DEPENDS += "util-linux"
+EXTRA_OEMAKE += "PKG_CONFIG=pkg-config"

--- a/meta-xt-security/recipes-security/optee/optee-examples.inc
+++ b/meta-xt-security/recipes-security/optee/optee-examples.inc
@@ -1,0 +1,46 @@
+SUMMARY = "OP-TEE examples"
+DESCRIPTION = "Open Portable Trusted Execution Environment - Sample Applications"
+HOMEPAGE = "https://github.com/linaro-swg/optee_examples"
+
+LICENSE = "BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=cd95ab417e23b94f381dafc453d70c30"
+
+DEPENDS = "optee-client optee-os-tadevkit python3-cryptography-native"
+
+inherit python3native
+
+require optee.inc
+
+SRC_URI = "git://github.com/linaro-swg/optee_examples.git;branch=master;protocol=https \
+           "
+
+EXTRA_OEMAKE += "TA_DEV_KIT_DIR=${TA_DEV_KIT_DIR} \
+                 HOST_CROSS_COMPILE=${HOST_PREFIX} \
+                 TA_CROSS_COMPILE=${HOST_PREFIX} \
+                 OUTPUT_DIR=${B} \
+               "
+
+S = "${WORKDIR}/git"
+B = "${WORKDIR}/build"
+
+
+do_compile() {
+    oe_runmake -C ${S}
+}
+do_compile[cleandirs] = "${B}"
+
+do_install () {
+    mkdir -p ${D}${nonarch_base_libdir}/optee_armtz
+    mkdir -p ${D}${bindir}
+    mkdir -p ${D}${libdir}/tee-supplicant/plugins
+    install -D -p -m0755 ${B}/ca/* ${D}${bindir}
+    install -D -p -m0444 ${B}/ta/* ${D}${nonarch_base_libdir}/optee_armtz
+    install -D -p -m0444 ${B}/plugins/* ${D}${libdir}/tee-supplicant/plugins
+}
+
+FILES:${PN} += "${nonarch_base_libdir}/optee_armtz/ \
+                ${libdir}/tee-supplicant/plugins/ \
+               "
+
+# Imports machine specific configs from staging to build
+PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/meta-xt-security/recipes-security/optee/optee-examples_4.1.0.bb
+++ b/meta-xt-security/recipes-security/optee/optee-examples_4.1.0.bb
@@ -1,0 +1,3 @@
+require recipes-security/optee/optee-examples.inc
+
+SRCREV = "378dc0db2d5dd279f58a3b6cb3f78ffd6b165035"

--- a/meta-xt-security/recipes-security/optee/optee-os-tadevkit_4.1.0.bb
+++ b/meta-xt-security/recipes-security/optee/optee-os-tadevkit_4.1.0.bb
@@ -1,0 +1,29 @@
+require recipes-security/optee/optee-os_${PV}.bb
+
+SUMMARY = "OP-TEE Trusted OS TA devkit"
+DESCRIPTION = "OP-TEE TA devkit for build TAs"
+HOMEPAGE = "https://www.op-tee.org/"
+
+DEPENDS += "python3-pycryptodome-native"
+
+do_install() {
+    #install TA devkit
+    install -d ${D}${includedir}/optee/export-user_ta/
+    for f in ${B}/export-ta_${OPTEE_ARCH}/* ; do
+        cp -aR $f ${D}${includedir}/optee/export-user_ta/
+    done
+}
+
+do_deploy() {
+	echo "Do not inherit do_deploy from optee-os."
+}
+
+FILES:${PN} = "${includedir}/optee/"
+
+# Build paths are currently embedded
+INSANE_SKIP:${PN}-dev += "buildpaths"
+
+# Include extra headers needed by SPMC tests to TA DEVKIT.
+# Supported after op-tee v3.20
+EXTRA_OEMAKE:append = "${@bb.utils.contains('MACHINE_FEATURES', 'optee-spmc-test', \
+                                        ' CFG_SPMC_TESTS=y', '' , d)}"

--- a/meta-xt-security/recipes-security/optee/optee-os.inc
+++ b/meta-xt-security/recipes-security/optee/optee-os.inc
@@ -1,0 +1,83 @@
+SUMMARY = "OP-TEE Trusted OS"
+DESCRIPTION = "Open Portable Trusted Execution Environment - Trusted side of the TEE"
+HOMEPAGE = "https://www.op-tee.org/"
+
+LICENSE = "BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=c1f21c4f72f372ef38a5a4aee55ec173"
+
+inherit deploy python3native
+require optee.inc
+
+CVE_PRODUCT = "linaro:op-tee op-tee:op-tee_os"
+
+DEPENDS = "python3-pyelftools-native python3-cryptography-native"
+
+DEPENDS:append:toolchain-clang = " compiler-rt"
+
+SRC_URI = "git://github.com/OP-TEE/optee_os.git;branch=master;protocol=https"
+
+S = "${WORKDIR}/git"
+B = "${WORKDIR}/build"
+
+EXTRA_OEMAKE += " \
+    PLATFORM=${OPTEEMACHINE} \
+    CFG_${OPTEE_CORE}_core=y \
+    CROSS_COMPILE_core=${HOST_PREFIX} \
+    CROSS_COMPILE_ta_${OPTEE_ARCH}=${HOST_PREFIX} \
+    NOWERROR=1 \
+    ta-targets=ta_${OPTEE_ARCH} \
+    O=${B} \
+"
+EXTRA_OEMAKE += " HOST_PREFIX=${HOST_PREFIX}"
+EXTRA_OEMAKE += " CROSS_COMPILE64=${HOST_PREFIX}"
+
+LDFLAGS[unexport] = "1"
+CPPFLAGS[unexport] = "1"
+AS[unexport] = "1"
+LD[unexport] = "1"
+
+do_compile:prepend() {
+	PLAT_LIBGCC_PATH=$(${CC} -print-libgcc-file-name)
+}
+
+do_compile() {
+    oe_runmake -C ${S} all
+}
+do_compile[cleandirs] = "${B}"
+
+do_install() {
+    #install core in firmware
+    install -d ${D}${nonarch_base_libdir}/firmware/
+    install -m 644 ${B}/core/*.bin ${B}/core/tee.elf ${D}${nonarch_base_libdir}/firmware/
+
+    #install tas in optee_armtz
+    install -d ${D}${nonarch_base_libdir}/optee_armtz/
+    install -m 444 ${B}/ta/*/*.ta ${D}${nonarch_base_libdir}/optee_armtz
+}
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+do_deploy() {
+    install -d ${DEPLOYDIR}/${MLPREFIX}optee
+    install -m 644 ${D}${nonarch_base_libdir}/firmware/* ${DEPLOYDIR}/${MLPREFIX}optee
+
+    install -d ${DEPLOYDIR}/${MLPREFIX}optee/ta
+    install -m 644 ${B}/ta/*/*.elf ${DEPLOYDIR}/${MLPREFIX}optee/ta
+}
+
+addtask deploy before do_build after do_install
+
+SYSROOT_DIRS += "${nonarch_base_libdir}/firmware"
+
+PACKAGES += "${PN}-ta"
+FILES:${PN} = "${nonarch_base_libdir}/firmware/"
+FILES:${PN}-ta = "${nonarch_base_libdir}/optee_armtz/*"
+
+
+# note: "textrel" is not triggered on all archs
+INSANE_SKIP:${PN} = "textrel"
+# Build paths are currently embedded
+INSANE_SKIP:${PN} += "buildpaths"
+INSANE_SKIP:${PN}-dev = "staticdev"
+INHIBIT_PACKAGE_STRIP = "1"
+

--- a/meta-xt-security/recipes-security/optee/optee-os/0003-optee-enable-clang-support.patch
+++ b/meta-xt-security/recipes-security/optee/optee-os/0003-optee-enable-clang-support.patch
@@ -1,0 +1,30 @@
+From 59d4c190eae11c93b26cca5a7b005a17dadc8248 Mon Sep 17 00:00:00 2001
+From: Brett Warren <brett.warren@arm.com>
+Date: Wed, 23 Sep 2020 09:27:34 +0100
+Subject: [PATCH] optee: enable clang support
+
+When compiling with clang, the LIBGCC_LOCATE_CFLAG variable used
+to provide a sysroot wasn't included, which results in not locating
+compiler-rt. This is mitigated by including the variable as ammended.
+
+Upstream-Status: Pending
+ChangeId: 8ba69a4b2eb8ebaa047cb266c9aa6c2c3da45701
+Signed-off-by: Brett Warren <brett.warren@arm.com>
+
+---
+ mk/clang.mk | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/mk/clang.mk b/mk/clang.mk
+index a045beee8..1ebe2f702 100644
+--- a/mk/clang.mk
++++ b/mk/clang.mk
+@@ -30,7 +30,7 @@ comp-cflags-warns-clang := -Wno-language-extension-token \
+ 
+ # Note, use the compiler runtime library (libclang_rt.builtins.*.a) instead of
+ # libgcc for clang
+-libgcc$(sm)	:= $(shell $(CC$(sm)) $(CFLAGS$(arch-bits-$(sm))) \
++libgcc$(sm)	:= $(shell $(CC$(sm)) $(LIBGCC_LOCATE_CFLAGS) $(CFLAGS$(arch-bits-$(sm))) \
+ 			-rtlib=compiler-rt -print-libgcc-file-name 2> /dev/null)
+ 
+ # Core ASLR relies on the executable being ready to run from its preferred load

--- a/meta-xt-security/recipes-security/optee/optee-os_4.1.0.bb
+++ b/meta-xt-security/recipes-security/optee/optee-os_4.1.0.bb
@@ -1,0 +1,10 @@
+require recipes-security/optee/optee-os.inc
+
+DEPENDS += "dtc-native"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRCREV = "18b424c23aa5a798dfe2e4d20b4bde3919dc4e99"
+SRC_URI += " \
+    file://0003-optee-enable-clang-support.patch \
+   "

--- a/meta-xt-security/recipes-security/optee/optee-test.inc
+++ b/meta-xt-security/recipes-security/optee/optee-test.inc
@@ -1,0 +1,62 @@
+SUMMARY = "OP-TEE sanity testsuite"
+DESCRIPTION = "Open Portable Trusted Execution Environment - Test suite"
+HOMEPAGE = "https://www.op-tee.org/"
+
+LICENSE = "BSD-2-Clause & GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://LICENSE.md;md5=daa2bcccc666345ab8940aab1315a4fa"
+
+inherit python3native ptest
+inherit deploy
+require optee.inc
+
+DEPENDS = "optee-client optee-os-tadevkit python3-cryptography-native openssl"
+
+SRC_URI = "git://github.com/OP-TEE/optee_test.git;branch=master;protocol=https \
+           file://run-ptest \
+          "
+
+S = "${WORKDIR}/git"
+B = "${WORKDIR}/build"
+
+EXTRA_OEMAKE += "TA_DEV_KIT_DIR=${TA_DEV_KIT_DIR} \
+                 OPTEE_OPENSSL_EXPORT=${STAGING_INCDIR} \
+                 CROSS_COMPILE_HOST=${HOST_PREFIX} \
+                 CROSS_COMPILE_TA=${HOST_PREFIX} \
+                 O=${B} \
+               "
+
+CFLAGS += "-Wno-error=deprecated-declarations"
+
+do_compile() {
+    cd ${S}
+    # Top level makefile doesn't seem to handle parallel make gracefully
+    oe_runmake xtest
+    oe_runmake ta
+    oe_runmake test_plugin
+}
+do_compile[cleandirs] = "${B}"
+
+do_install () {
+    install -D -p -m0755 ${B}/xtest/xtest ${D}${bindir}/xtest
+
+    # install path should match the value set in optee-client/tee-supplicant
+    # default TEEC_LOAD_PATH is /lib
+    mkdir -p ${D}${nonarch_base_libdir}/optee_armtz/
+    install -D -p -m0444 ${B}/ta/*/*.ta ${D}${nonarch_base_libdir}/optee_armtz/
+    mkdir -p ${D}${libdir}/tee-supplicant/plugins
+    install -D -p -m0444 ${B}/supp_plugin/*.plugin ${D}${libdir}/tee-supplicant/plugins/
+}
+
+do_deploy () {
+    install -d ${DEPLOYDIR}/${MLPREFIX}optee/ta
+    install -m 644 ${B}/ta/*/*.elf ${DEPLOYDIR}/${MLPREFIX}optee/ta
+}
+
+addtask deploy before do_build after do_install
+
+FILES:${PN} += "${nonarch_base_libdir}/optee_armtz/ \
+                ${libdir}/tee-supplicant/plugins/ \
+               "
+
+# Imports machine specific configs from staging to build
+PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/meta-xt-security/recipes-security/optee/optee-test/0001-xtest-stats-remove-unneeded-stat.h-include.patch
+++ b/meta-xt-security/recipes-security/optee/optee-test/0001-xtest-stats-remove-unneeded-stat.h-include.patch
@@ -1,0 +1,34 @@
+From 236ebb968a298fa5d461e734559ad8a13b667eb6 Mon Sep 17 00:00:00 2001
+From: Jon Mason <jon.mason@arm.com>
+Date: Wed, 24 Jan 2024 11:35:50 -0500
+Subject: [PATCH] xtest: stats: remove unneeded stat.h include
+
+Hack to work around musl compile error:
+
+| In file included from optee-test/4.1.0/recipe-sysroot/usr/include/sys/stat.h:23,
+|                  from optee-test/4.1.0/git/host/xtest/stats.c:17:
+| optee-test/4.1.0/recipe-sysroot/usr/include/bits/stat.h:17:26: error: expected identifier or '(' before '[' token
+|    17 |         unsigned __unused[2];
+|       |                          ^
+
+stat.h is not needed, since it is not being used in this file.  So
+removing it.
+
+Upstream-Status: Inappropriate [https://github.com/OP-TEE/optee_test/issues/722]
+Signed-off-by: Jon Mason <jon.mason@arm.com>
+---
+ host/xtest/stats.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/host/xtest/stats.c b/host/xtest/stats.c
+index fb16d55586da..05aa3adac611 100644
+--- a/host/xtest/stats.c
++++ b/host/xtest/stats.c
+@@ -14,7 +14,6 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+-#include <sys/stat.h>
+ #include <sys/types.h>
+ #include <tee_client_api.h>
+ #include <unistd.h>

--- a/meta-xt-security/recipes-security/optee/optee-test/run-ptest
+++ b/meta-xt-security/recipes-security/optee/optee-test/run-ptest
@@ -1,0 +1,52 @@
+#!/bin/sh
+xtest | awk '
+
+    # Escapes the special characters in a string so that, when
+    # included in a regex, it represents a literal match
+    function regx_escape_literal(str,    ret) {
+        ret = str
+        gsub(/[\[\]\^\$\.\*\?\+\{\}\\\(\)\|]/ , "\\\\&", str)
+        return str
+    }
+
+    # Returns the simple test formatted name
+    function name(n,    ret) {
+        ret = n
+        gsub(/\./, " ", ret)
+        return ret
+    }
+
+    # Returns the simple test formatted result
+    function result(res) {
+        if(res ~ /OK/) {
+            return "PASS"
+        } else if(res ~ /FAILED/) {
+            return "FAIL"
+        }
+    }
+
+    function parse(name, description,     has_subtests, result_line) {
+        has_subtests = 0
+
+        # Consume every line up to the result line
+        result_line = "  " regx_escape_literal(name) " (OK|FAILED)"
+        do {
+            getline
+
+            # If this is a subtest (denoted by an "o" bullet) then subparse
+            if($0 ~ /^o /) {
+                parse($2, description " : " substr($0, index($0, $3)))
+                has_subtests = 1
+            }
+        } while ($0 !~ result_line)
+
+        # Only print the results for the deepest nested subtests
+        if(!has_subtests) {
+            print result($2) ": " name(name) " - " description
+        }
+    }
+
+    # Start parsing at the beginning of every test (denoted by a "*" bullet)
+    /^\* / { parse($2, substr($0, index($0, $3))) }
+
+'

--- a/meta-xt-security/recipes-security/optee/optee-test_4.1.0.bb
+++ b/meta-xt-security/recipes-security/optee/optee-test_4.1.0.bb
@@ -1,0 +1,12 @@
+require recipes-security/optee/optee-test.inc
+
+SRCREV = "2e1e7a9c9d659585566a75fc8802f4758c42bcb2"
+SRC_URI += "file://0001-xtest-stats-remove-unneeded-stat.h-include.patch"
+
+# Include ffa_spmc test group if the SPMC test is enabled.
+# Supported after op-tee v3.20
+EXTRA_OEMAKE:append = "${@bb.utils.contains('MACHINE_FEATURES', 'optee-spmc-test', \
+                                        ' CFG_SPMC_TESTS=y CFG_SECURE_PARTITION=y', '' , d)}"
+
+RDEPENDS:${PN} += "${@bb.utils.contains('MACHINE_FEATURES', 'optee-spmc-test', \
+                                              ' arm-ffa-user', '' , d)}"

--- a/meta-xt-security/recipes-security/optee/optee.inc
+++ b/meta-xt-security/recipes-security/optee/optee.inc
@@ -1,0 +1,41 @@
+UPSTREAM_CHECK_GITTAGREGEX = "^(?P<pver>\d+(\.\d+)+)$"
+
+COMPATIBLE_MACHINE ?= "invalid"
+COMPATIBLE_MACHINE:qemuarm64 ?= "qemuarm64"
+COMPATIBLE_MACHINE:qemu-generic-arm64 ?= "qemu-generic-arm64"
+COMPATIBLE_MACHINE:qemuarm ?= "qemuarm"
+# Please add supported machines below or set it in .bbappend or .conf
+
+OPTEEMACHINE ?= "${MACHINE}"
+OPTEEMACHINE:aarch64:qemuall ?= "vexpress-qemu_armv8a"
+OPTEEMACHINE:arm:qemuall ?= "vexpress-qemu_virt"
+
+OPTEE_ARCH = "null"
+OPTEE_ARCH:arm = "arm32"
+OPTEE_ARCH:aarch64 = "arm64"
+OPTEE_CORE = "${@d.getVar('OPTEE_ARCH').upper()}"
+
+# FIXME - breaks with Clang 18.  See https://github.com/OP-TEE/optee_os/issues/6754
+TOOLCHAIN = "gcc"
+
+OPTEE_TOOLCHAIN = "${@d.getVar('TOOLCHAIN') or 'gcc'}"
+OPTEE_COMPILER = "${@bb.utils.contains("BBFILE_COLLECTIONS", "clang-layer", "${OPTEE_TOOLCHAIN}", "gcc", d)}"
+
+# Set here but not passed to EXTRA_OEMAKE by default as that breaks
+# the optee-os build
+TA_DEV_KIT_DIR = "${STAGING_INCDIR}/optee/export-user_ta"
+
+EXTRA_OEMAKE += "V=1 \
+                 LIBGCC_LOCATE_CFLAGS='${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS}' \
+                 COMPILER=${OPTEE_COMPILER} \
+                 OPTEE_CLIENT_EXPORT=${STAGING_DIR_HOST}${prefix} \
+                 TEEC_EXPORT=${STAGING_DIR_HOST}${prefix} \
+                "
+# python3-cryptography needs the legacy provider, so set OPENSSL_MODULES to the
+# right path until this is relocated automatically.
+export OPENSSL_MODULES="${STAGING_LIBDIR_NATIVE}/ossl-modules"
+
+CFLAGS += "--sysroot=${STAGING_DIR_HOST}"
+
+# See the rationale in https://github.com/f-secure-foundry/advisories/blob/master/Security_Advisory-Ref_FSC-HWSEC-VR2021-0001-OP-TEE_TrustZone_bypass.txt.
+CVE_STATUS[CVE-2021-36133] = "disputed: devices shipped open for development purposes"


### PR DESCRIPTION
Add meta-xt-security layer that hosts OP-TEE-related recipes. Those recipes were taken from meta-arm. We can't use meta-arm directly, because it depends on meta-arm-toolchain and we are not ready to switch the toolchain for all our products.

This is only partial copy of meta-arm/recipes-security, because original also includes recipes for Trusted Services and we don't need them yet.