### PR TITLE
qemu: use the yocto method to fetch git submodules

### DIFF
--- a/meta-xt-qemu/recipes-qemu/qemu/qemu.inc
+++ b/meta-xt-qemu/recipes-qemu/qemu/qemu.inc
@@ -14,7 +14,7 @@ inherit pkgconfig ptest
 LIC_FILES_CHKSUM = "file://COPYING;md5=441c28d2cf86e15a37fa47e15a72fbac \
                     file://COPYING.LIB;endline=24;md5=8c5efda6cf1e1b03dcfd0e6c0d271c7f"
 
-SRC_URI = "git://github.com/xen-troops/qemu.git;branch=v7.0.0-xt;protocol=https;submodules=1 \
+SRC_URI = "gitsm://github.com/xen-troops/qemu.git;branch=v7.0.0-xt;protocol=https \
            file://powerpc_rom.bin \
            file://run-ptest \
            "
@@ -94,11 +94,6 @@ EXTRA_OECONF = " \
 B = "${WORKDIR}/build"
 
 #EXTRA_OECONF:append = " --python=${HOSTTOOLS_DIR}/python3"
-
-do_configure:prepend() {
-    git -C ${S} submodule init
-    git -C ${S} submodule update --recursive
-}
 
 do_configure:prepend:class-native() {
 	# Append build host pkg-config paths for native target since the host may provide sdl


### PR DESCRIPTION
According to the documentation:
https://docs.yoctoproject.org/bitbake/2.0/bitbake-user-manual/bitbake-user-manual-fetching.html#git-submodule-fetcher-gitsm

the yocto method involves using gitsm instead of manual scripts. The 'submodules=1' option has been removed because it is not recognized.