### PR TITLE
doma: enable network in do_compile for u-boot-android-bazel

### DIFF
--- a/meta-xt-control-domain/recipes-guest/doma/u-boot-android-bazel_1.0.0.bb
+++ b/meta-xt-control-domain/recipes-guest/doma/u-boot-android-bazel_1.0.0.bb
@@ -27,6 +27,8 @@ LIC_FILES_CHKSUM = "file://${WORKDIR}/repo/u-boot/Licenses/README;md5=2ca5f2c35c
 FILES:${PN} = "\
                ${libdir}/xen/boot/u-boot-doma \
                "
+# Enable network in do_compile, since bazel spawns client and server with socket communication
+do_compile[network] = "1"
 
 do_compile() {
     cd ${WORKDIR}/repo;


### PR DESCRIPTION
u-boot-android-bazel directly calls Bazel inside do_compile. At the same time, the Bazel build spawns client and server instances, which use sockets for communication. Enable the network for this use-case, which is disabled by default.