### PR TITLE
backends: remove `RRECOMMENDS = virtual/xenstored`

### DIFF
--- a/meta-xt-driver-domain/recipes-connectivity/xen-network/xen-network.bb
+++ b/meta-xt-driver-domain/recipes-connectivity/xen-network/xen-network.bb
@@ -39,10 +39,6 @@ RDEPENDS:${PN} = " \
     xen-tools-xenstore \
 "
 
-RRECOMMENDS:${PN} += " \
-    virtual/xenstored \
-"
-
 do_install() {
     # Install bridge/network artifacts
     install -d ${D}${systemd_system_unitdir}

--- a/meta-xt-driver-domain/recipes-extended/block/block.bb
+++ b/meta-xt-driver-domain/recipes-extended/block/block.bb
@@ -17,10 +17,6 @@ RDEPENDS:${PN} += " \
     xen-tools-xenstore \
 "
 
-RRECOMMENDS:${PN} += " \
-    virtual/xenstored \
-"
-
 FILES:${PN} = " \
     ${systemd_system_unitdir}/block-up-notification.service \
 "

--- a/meta-xt-driver-domain/recipes-extended/camerabe/camerabe_git.bb
+++ b/meta-xt-driver-domain/recipes-extended/camerabe/camerabe_git.bb
@@ -26,10 +26,6 @@ RDEPENDS:${PN} += " \
     xen-tools-xenstore \
 "
 
-RRECOMMENDS:${PN} += " \
-    virtual/xenstored \
-"
-
 PACKAGECONFIG ??= ""
 PACKAGECONFIG[doc] = "-DWITH_DOC=ON,-DWITH_DOC=OFF,doxygen-native"
 

--- a/meta-xt-driver-domain/recipes-extended/displbe/displbe_git.bb
+++ b/meta-xt-driver-domain/recipes-extended/displbe/displbe_git.bb
@@ -41,10 +41,6 @@ RDEPENDS:${PN} += " \
     xen-tools-xenstore \
 "
 
-RRECOMMENDS:${PN} += " \
-    virtual/xenstored \
-"
-
 FILES:${PN} += " \
     ${systemd_system_unitdir}/displbe.service \
 "

--- a/meta-xt-driver-domain/recipes-extended/sndbe/sndbe_git.bb
+++ b/meta-xt-driver-domain/recipes-extended/sndbe/sndbe_git.bb
@@ -18,10 +18,6 @@ RDEPENDS:${PN} += " \
     xen-tools-xenstore \
 "
 
-RRECOMMENDS:${PN} += " \
-    virtual/xenstored \
-"
-
 SRC_URI = " \
     git://github.com/xen-troops/snd_be.git;protocol=https;branch=master \
     file://sndbe.service \

--- a/meta-xt-driver-domain/recipes-extended/virtio-disk/virtio-disk.bb
+++ b/meta-xt-driver-domain/recipes-extended/virtio-disk/virtio-disk.bb
@@ -24,10 +24,6 @@ RDEPENDS:${PN} += " \
     xen-tools-xenstore \
 "
 
-RRECOMMENDS:${PN} += " \
-    virtual/xenstored \
-"
-
 do_install:append() {
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/virtio-disk.service ${D}${systemd_system_unitdir}


### PR DESCRIPTION
The `RRECOMMENDS` is used to extend the usability and should is used to list packages that are not required, but nice to have. But `xenstore` is critical for the backends.

At the same time, we see that all backends have `RDEPENDS = xen-tools-xenstore` and this is the proper solution.

So, this commit removes useless `RRECOMMENDS = virtual/xenstored` from backend recipes.