### PR TITLE
dom0: remove base.bbclass from doma's u-boot

### DIFF
--- a/meta-xt-control-domain/recipes-guest/doma/u-boot-android-bazel_1.0.0.bb
+++ b/meta-xt-control-domain/recipes-guest/doma/u-boot-android-bazel_1.0.0.bb
@@ -1,8 +1,6 @@
 SUMMARY = "Deployment of Android U-Boot, which is built by the Bazel build system."
 DESCRIPTION = "Android U-Boot is a standard tool to boot Android."
 
-inherit base
-
 # PARAMETERS
 
 UBOOT_REPO_GIT_URL ?= "github.com/xen-troops/android_u-boot_manifest"


### PR DESCRIPTION
There is no need to `inherit base` because this bbclass is implicitly inherited by all recipes.