### PR TITLE
Add recipes for OP-TEE v4.2.0 as it is required by RPI5 product

### DIFF
--- a/meta-xt-security/recipes-security/optee/optee-client_4.2.0.bb
+++ b/meta-xt-security/recipes-security/optee/optee-client_4.2.0.bb
@@ -1,0 +1,10 @@
+require recipes-security/optee/optee-client.inc
+
+SRCREV = "3eac340a781c00ccd61b151b0e9c22a8c6e9f9f0"
+
+inherit pkgconfig
+DEPENDS += "util-linux"
+EXTRA_OEMAKE += "PKG_CONFIG=pkg-config"
+
+# Prevent using newer version in incompatible products
+COMPATIBLE_MACHINE ?= "invalid"

--- a/meta-xt-security/recipes-security/optee/optee-os-tadevkit.inc
+++ b/meta-xt-security/recipes-security/optee/optee-os-tadevkit.inc
@@ -1,0 +1,29 @@
+require recipes-security/optee/optee-os_${PV}.bb
+
+SUMMARY = "OP-TEE Trusted OS TA devkit"
+DESCRIPTION = "OP-TEE TA devkit for build TAs"
+HOMEPAGE = "https://www.op-tee.org/"
+
+DEPENDS += "python3-pycryptodome-native"
+
+do_install() {
+    #install TA devkit
+    install -d ${D}${includedir}/optee/export-user_ta/
+    for f in ${B}/export-ta_${OPTEE_ARCH}/* ; do
+        cp -aR $f ${D}${includedir}/optee/export-user_ta/
+    done
+}
+
+do_deploy() {
+	echo "Do not inherit do_deploy from optee-os."
+}
+
+FILES:${PN} = "${includedir}/optee/"
+
+# Build paths are currently embedded
+INSANE_SKIP:${PN}-dev += "buildpaths"
+
+# Include extra headers needed by SPMC tests to TA DEVKIT.
+# Supported after op-tee v3.20
+EXTRA_OEMAKE:append = "${@bb.utils.contains('MACHINE_FEATURES', 'optee-spmc-test', \
+                                        ' CFG_SPMC_TESTS=y', '' , d)}"

--- a/meta-xt-security/recipes-security/optee/optee-os-tadevkit_4.1.0.bb
+++ b/meta-xt-security/recipes-security/optee/optee-os-tadevkit_4.1.0.bb
@@ -1,29 +1,5 @@
-require recipes-security/optee/optee-os_${PV}.bb
+# Need to set PV manually or Bitbake tries to extract it
+# from "optee-os-tadevkit.inc" filename
+PV="4.1.0"
 
-SUMMARY = "OP-TEE Trusted OS TA devkit"
-DESCRIPTION = "OP-TEE TA devkit for build TAs"
-HOMEPAGE = "https://www.op-tee.org/"
-
-DEPENDS += "python3-pycryptodome-native"
-
-do_install() {
-    #install TA devkit
-    install -d ${D}${includedir}/optee/export-user_ta/
-    for f in ${B}/export-ta_${OPTEE_ARCH}/* ; do
-        cp -aR $f ${D}${includedir}/optee/export-user_ta/
-    done
-}
-
-do_deploy() {
-	echo "Do not inherit do_deploy from optee-os."
-}
-
-FILES:${PN} = "${includedir}/optee/"
-
-# Build paths are currently embedded
-INSANE_SKIP:${PN}-dev += "buildpaths"
-
-# Include extra headers needed by SPMC tests to TA DEVKIT.
-# Supported after op-tee v3.20
-EXTRA_OEMAKE:append = "${@bb.utils.contains('MACHINE_FEATURES', 'optee-spmc-test', \
-                                        ' CFG_SPMC_TESTS=y', '' , d)}"
+require optee-os-tadevkit.inc

--- a/meta-xt-security/recipes-security/optee/optee-os-tadevkit_4.2.0.bb
+++ b/meta-xt-security/recipes-security/optee/optee-os-tadevkit_4.2.0.bb
@@ -1,0 +1,5 @@
+# Need to set PV manually or Bitbake tries to extract it
+# from "optee-os-tadevkit.inc" filename
+PV="4.2.0"
+
+require optee-os-tadevkit.inc

--- a/meta-xt-security/recipes-security/optee/optee-os_4.2.0.bb
+++ b/meta-xt-security/recipes-security/optee/optee-os_4.2.0.bb
@@ -1,0 +1,3 @@
+require recipes-security/optee/optee-os.inc
+
+SRCREV = "12d7c4ee4642d2d761e39fbcf21a06fb77141dea"

--- a/meta-xt-security/recipes-security/optee/optee-test_4.2.0.bb
+++ b/meta-xt-security/recipes-security/optee/optee-test_4.2.0.bb
@@ -1,0 +1,3 @@
+require recipes-security/optee/optee-test.inc
+
+SRCREV = "526d5bac1b65f907f67c05cd07beca72fbab88dd"


### PR DESCRIPTION
Other products will use v4.1.0 because of absence of `.bbappends` witch   `COMPATIBLE_MACHINE` for new version.

Build tested for salvator-x-8gb. 