### PR TITLE
[UNDER TEST] Use linux-libc-headers properly

### DIFF
--- a/meta-xt-domu/recipes-kernel/linux-libc-headers/linux-libc-headers_5.10.bb
+++ b/meta-xt-domu/recipes-kernel/linux-libc-headers/linux-libc-headers_5.10.bb
@@ -1,5 +1,5 @@
 require recipes-kernel/linux-libc-headers/linux-libc-headers.inc
 
-SRC_URI[sha256sum] = "c969dea4e8bb6be991bbf7c010ba0e0a5643a3a8d8fb0a2aaa053406f1e965f3"
+SRC_URI[sha256sum] = "dcdf99e43e98330d925016985bfbc7b83c66d367b714b2de0cbbfcbf83d8ca43"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"

--- a/meta-xt-domx/recipes-kernel/linux-libc-headers/linux-libc-headers_5.10.bb
+++ b/meta-xt-domx/recipes-kernel/linux-libc-headers/linux-libc-headers_5.10.bb
@@ -1,5 +1,5 @@
 require recipes-kernel/linux-libc-headers/linux-libc-headers.inc
 
-SRC_URI[sha256sum] = "c969dea4e8bb6be991bbf7c010ba0e0a5643a3a8d8fb0a2aaa053406f1e965f3"
+SRC_URI[sha256sum] = "dcdf99e43e98330d925016985bfbc7b83c66d367b714b2de0cbbfcbf83d8ca43"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"

--- a/meta-xt-domx/recipes-kernel/linux-libc-headers/linux-libc-headers_6.8.bb
+++ b/meta-xt-domx/recipes-kernel/linux-libc-headers/linux-libc-headers_6.8.bb
@@ -1,13 +1,5 @@
 require recipes-kernel/linux-libc-headers/linux-libc-headers.inc
 
-KERNEL_URL = "git://github.com/torvalds/linux.git"
-BRANCH = "master"
-SRCREV = "6613476e225e090cc9aad49be7fa504e290dd33d"
-LINUX_VERSION = "6.8.0-rc1"
-
-SRC_URI = "${KERNEL_URL};branch=${BRANCH};protocol=https"
-
+SRC_URI[sha256sum] = "c969dea4e8bb6be991bbf7c010ba0e0a5643a3a8d8fb0a2aaa053406f1e965f3"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
-
-S = "${WORKDIR}/git"


### PR DESCRIPTION
This commit updates the linux-libc-headers recipe to use the upstream version of the headers from kernel.org, as suggested by the poky's `linux-libc-headers.inc`.

The previous version of the recipe relied on a vendor snapshot of the headers, which required fetching the entire kernel source. This could sometimes lead to fetch errors due to simultaneous fetches of the same sources for linux-libc-headers and linux-renesas.

However, it's sufficient to fetch the standard package provided by the kernel maintainers.

Taking into account the URL for downloading of the package requires PV provided, and different versions have different hash, this commit adds recipes for all kernels that we use now:
- Dom0 - 6.8
- DomD - 5.10
- DomU - 5.10 or 6.8

Also recipes for the DomU are duplicated in the dedicated directory, because this allows to smoothly switch incorrect usage of the headers to the correct one, in a few products without modification of the DomU's layers.