### PR TITLE
doma: add fastboot port forwarding

### DIFF
--- a/meta-xt-driver-domain/recipes-connectivity/xen-network/xen-network.bb
+++ b/meta-xt-driver-domain/recipes-connectivity/xen-network/xen-network.bb
@@ -66,6 +66,8 @@ do_install() {
             >> ${D}${sysconfdir}/systemd/system/systemd-networkd.service.d/port-forward-systemd-networkd.conf
         echo "ExecStartPost=+/usr/sbin/iptables -t nat -A PREROUTING -i end0 -p tcp --dport 5555 -j DNAT --to-destination ${XT_DOMA_FORWARD_DESTINATION}:5555" \
             >> ${D}${sysconfdir}/systemd/system/systemd-networkd.service.d/port-forward-systemd-networkd.conf
+        echo "ExecStartPost=+/usr/sbin/iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 5554 -j DNAT --to-destination ${XT_DOMA_FORWARD_DESTINATION}:5554" \
+            >> ${D}${sysconfdir}/systemd/system/systemd-networkd.service.d/port-forward-systemd-networkd.conf
     fi
     if ${@bb.utils.contains('XT_GUEST_INSTALL', 'domu', 'true', 'false', d)}; then
         echo "# SSH to domU" \


### PR DESCRIPTION
Enhance support for fastboot over the network by
implementing correct port 5554 forwarding.