### PR TITLE
dom0: add missing dependencies to start DomD

### DIFF
--- a/meta-xt-control-domain/recipes-guest/domd/files/domd.service
+++ b/meta-xt-control-domain/recipes-guest/domd/files/domd.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=DomD
-Requires=proc-xen.mount
-After=proc-xen.mount
+Requires=proc-xen.mount xenstored.service xenconsoled.service
+After=proc-xen.mount xenstored.service xenconsoled.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Currently, due to race conditions, xenstore and xenconsole services may start after launching DomD and as a result, starting DomD fails. Adding proper systmemd dependencies fixes this issue.